### PR TITLE
Ajout du tutoriel pour l'adaptation du modèle de calcul

### DIFF
--- a/INTERNATIONAL.md
+++ b/INTERNATIONAL.md
@@ -1,6 +1,6 @@
 # International
 
-> For now, Nos Gestes Climat website and model programming language Publi.codes are only available in French. We intend to provide international solution of Nos Gestes Climat to help you to adapt the calculator to your country within few weeks. We are testing a multi-model version for francophones, that's why this guide is written in French.
+> 🇬🇧 For now, the programming language used by Nos Gestes Climat, named publi.codes, is only available in French. We intend to provide an easy framework to help you adapt the calculator to your country within a few weeks. We are testing a multi-region but only for francophone regions for now, which is why this guide is written in French.
 
 L'internationalisation de Nos Gestes Climat est complexe : il n'est pas seulement question de simple traduction linguistique mais de la mise en place d'une solution permettant d'adapter la langue et le modèle de calcul en fonction du pays.
 


### PR DESCRIPTION
Pour cette V1 du tuto (en français pour l'instant), il est question de la création d'un modèle de calcul divergent du modèle de référence destiné aux francophones 

- [x] Relire
- [x] Infos manquantes ?
- [ ] une fois mis en ligne, changer le lien hedgedoc dans components/localisation