### PR TITLE
Nouvelles actions transport

### DIFF
--- a/data/transport/actions/limitation-vitesse.yaml
+++ b/data/transport/actions/limitation-vitesse.yaml
@@ -2,6 +2,7 @@ transport . voiture . limitation autoroute:
   titre: Passer de 130 à 110km/h
   icônes: 🚗🛣️
   formule: réduction * empreinte autoroute
+  nonn applicable si: covoitureur
   description: |
     La convention citoyenne pour le climat a proposé en 2020 une réduction de la limitation de vitesse sur les autoroutes de 130km/h à 110km/h. 
     La proposition est détaillée [ici](https://propositions.conventioncitoyennepourleclimat.fr/objectif/reduire-les-emissions-des-gaz-a-effet-de-serre-sur-les-autoroutes-et-les-voies-rapides/#elementor-tab-title-1681). 

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -102,6 +102,7 @@ transport . prendre moins l'avion:
 
 transport . éco-conduite:
   titre: Adopter une éco-conduite
+  non applicable si: covoitureur
   effort: faible
   icônes: 🚗☮
   formule: transport . voiture . empreinte - transport . éco-conduite . recalcul
@@ -133,6 +134,24 @@ transport . éco-conduite . usage réduit:
   unité: kgCO2e
   note: réduction de 15% (cf info règle éco-conduite)
 
+transport . voiture . profil . locataire:
+  titre: locataire
+  applicable si:
+    toutes ces conditions:
+      - propriétaire = non
+      - km > 0
+      - voyageurs < 2
+  note: avec cette variable on définit (imparfaitement) le profil locataire de voiture
+    
+transport . voiture . profil . covoitureur:
+  titre: covoitureurs
+  applicable si:
+    toutes ces conditions:
+      - propriétaire = non
+      - km > 0
+      - voyageurs > 2
+  note: avec cette variable on définit (imparafaitement) le profil covoitureur
+
 transport . covoiturage:
   titre: Privilégier le covoiturage
   effort: modéré
@@ -155,11 +174,15 @@ transport . covoiturage:
 transport . voiture . trajets longs . covoiturage:
   titre: Covoiturer sur vos trajets long
   icônes: 🚗👥  
-  applicable si: voyageurs < 2
   applicable si:
-    toutes ces conditions:
-      - voiture . propriétaire
-      - voiture . voyageurs < 2
+    variations:
+      - si:
+        toutes ces conditions:
+          - voiture . propriétaire
+          - voiture . voyageurs < 2
+       - si:
+         une de ces conditions:
+          - locataire
   formule: empreinte . usage * trajets longs . part / (voyageurs + 1)
   descritption: |
     Covoiturer sur des longues distances est un moyen facile de réduire son empreinte sur le climat. Et puis c'est économique !
@@ -374,7 +397,10 @@ transport . voiture 5km:
   titre: Se passer de voiture pour moins de 5 km
   icônes: 🚗🚲
   formule: transport . voiture . empreinte - transport . voiture 5km . recalcul
-  non applicable si: voiture . km < seuil d'activation 5km
+  non applicable si: 
+    une de ces conditions: 
+      - voiture . km < seuil d'activation 5km
+      - propriétaire = non
   description: |
     En France, 4 trajets en voiture sur 10 font moins de 3 km et ce n’est pas moins de 177 millions de trajets de moins de 5km qui sont réalisés seuls en voiture chaque semaine (hors trajets domicile-travail). 
 

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -499,3 +499,20 @@ transport . âge nouvelle voiture électrique . occasion:
 
   par défaut: oui
 # L'action disparait quand l'impact climat devient positif
+
+transport . voiture . arrêter trajets longs:
+  titre: Privilégier le train aux longs trajets en voiture
+  icônes: 🚆🚗
+  formule: (empreinte . usage * part trajets longs / voyageurs) - (voiture . km * part trajets longs * train . impact par km * voyageurs)
+  note: |
+    Formule à revoir pour s'assurer de la cohérence avec le nombre de voyageurs et les km à considérer.
+    Remarque : dans l'idéal il faudrait que l'on considère ici les voyageurs en trajets longs car dans le cas de Medhi d'Agen on a 2,33 voyageurs moyens car il fait des km
+    D-T seul mais beaucoup de weekends/vacances en famille (4 voyageurs)
+  
+transport . voiture . part trajets longs:
+  question: Quelle proportion des km parcourus dans l'année dépasse plus de 30 km ?
+  description: |
+    On cherche à évaluer la part des trajets longs dans vos km totaux roulés
+  par défaut: 50%
+  note: Ce seuil de 30 km est abitraire -> à réflechir. Il pourrait être considéré aussi que les km trajets longs sont tout ce qui n'est pas déplacement D-T, trajets -5km
+  

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -152,6 +152,21 @@ transport . covoiturage:
   références:
     - https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122
 
+transport . voiture . trajets longs . covoiturage:
+  titre: Covoiturer sur vos trajets long
+  icônes: 🚗👥  
+  applicable si: voyageurs < 2
+  applicable si:
+    toutes ces conditions:
+      - voiture . propriétaire
+      - voiture . voyageurs < 2
+  formule: empreinte . usage * trajets longs . part / (voyageurs + 1)
+  descritption: |
+    Covoiturer sur des longues distances est un moyen facile de réduire son empreinte sur le climat. Et puis c'est économique !
+  note: |
+    La formule est à retravailler et discuter (car le facteur réduction covoiturage de 20 % n'est peut être pas pertinent sur des longs trajets). Il s'agit ici de poser le 
+    cadre d'une action de covoiturage pour les trajets longue distance
+
 transport . boulot:
   icônes: 🏢
 transport . boulot . covoiturage:
@@ -500,16 +515,16 @@ transport . âge nouvelle voiture électrique . occasion:
   par défaut: oui
 # L'action disparait quand l'impact climat devient positif
 
-transport . voiture . arrêter trajets longs:
+transport . voiture . trajets longs . arrêter:
   titre: Privilégier le train aux longs trajets en voiture
   icônes: 🚆🚗
-  formule: (empreinte . usage * part trajets longs / voyageurs) - (voiture . km * part trajets longs * train . impact par km * voyageurs)
+  formule: (empreinte . usage * trajets longs . part / voyageurs) - (voiture . km * trajets longs . part * train . impact par km * voyageurs)
   note: |
     Formule à revoir pour s'assurer de la cohérence avec le nombre de voyageurs et les km à considérer.
     Remarque : dans l'idéal il faudrait que l'on considère ici les voyageurs en trajets longs car dans le cas de Medhi d'Agen on a 2,33 voyageurs moyens car il fait des km
     D-T seul mais beaucoup de weekends/vacances en famille (4 voyageurs)
   
-transport . voiture . part trajets longs:
+transport . voiture . trajets longs . part:
   question: Quelle proportion des km parcourus dans l'année dépasse plus de 30 km ?
   description: |
     On cherche à évaluer la part des trajets longs dans vos km totaux roulés

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -130,7 +130,7 @@ transport . éco-conduite . recalcul:
       # Can't do this : transport . voiture . empreinte . usage: transport . voiture . empreinte . usage * 0.85
 
 transport . éco-conduite . usage réduit:
-  formule: (transport . voiture . km * transport . voiture . empreinte . au kilomètre) * 0.85
+  formule: ((transport . voiture . km - transport . km autoroute) * transport . voiture . empreinte . au kilomètre) * 0.85
   unité: kgCO2e
   note: réduction de 15% (cf info règle éco-conduite)
 


### PR DESCRIPTION
Plusieurs de ces actions sont sous une forme "exploratoires" sur laquelle une passe sera nécessaire

**Remarques** :
- pour l'action "trajets longs en train plutôt qu'en voiture" elle est pertinente pour le persona Medhi d'Agen mais **dans un volet action retravaillé et idéal il faudrait évaluer l'offre de transport de train** (temps, horaires, prix) car 
  - difficile de pousser cette action si aucune alternative n'existe / est possible,
  - si la réponse met en avant qu'aucune offre de Train/TC existe -> il faudrait faire comprendre à ces profils que leur décarbonation passera par la décarbonation du système (les rendre moins auto dépendants pour résumer ici)
- pour la part de trajets longs, on pourrait éventuellement réutiliser la question sur le nb_km sur autoroute ? Mais on oublierait peut être des km (car il est possible que des trajets longs soient faits hors autoroute)
- l'action 110 km/h n'est-elle pas une partie de l'éco-conduite ? Oui si on en s'en réfère page 19 d'une des [sources](https://agirpourlatransition.ademe.fr/particuliers/sites/default/files/2020-09/guide-mobilite-10-questions.pdf) d'une fiche action. Une meilleure organisation de l’interaction de ces deux actions doit être fait. Je propose d'appliquer uniquement le coefficient de 15% sur les km hors autoroute afin de ne plus surestimer l'impact du combo 110 km/h + écoconduite
