### PR TITLE
adding a model for QC electricity mix.

### DIFF
--- a/data/i18n/models/CA-QC-fr.yaml
+++ b/data/i18n/models/CA-QC-fr.yaml
@@ -1,0 +1,10 @@
+params:
+  nom: Québec
+  code: CA-QC
+  gentilé: québécois
+
+intensité électricité:
+  titre: Intensité climat du mix électrique canadien (région Québec)
+  formule: 0.028
+  note: |
+    [Electricity Map](https://app.electricitymaps.com/zone/CA-QC), 2022, vision 5 ans, 2022


### PR DESCRIPTION
Essai d’un ajout de modèle pour le Québec, pour valider la possibilité d’utiliser les indicatifs ISO 3166-2 de provinces.