### PR TITLE
Migrate translate-rules script to mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"check:personas": "node scripts/i18n/check-personas.js ",
 		"translate:personas": "node scripts/i18n/translate-personas.js",
 		"check:rules": "node scripts/i18n/check-translation.mjs",
-		"translate:rules": "node scripts/i18n/translate-rules.js",
+		"translate:rules": "node scripts/i18n/translate-rules.mjs",
 		"generate:servicesRules": "node scripts/services-societaux/analyze_naf_ca.js && node scripts/services-societaux/desagregate_naf_SDES.js && node scripts/services-societaux/generate_rules.js",
 		"translate:model": "node scripts/i18n/translateRegionModel.js"
 	},


### PR DESCRIPTION
Suite à #2006 

## Changelog

* Switch script `translate-rules` depending on `@incubateur-ademe/publicodes-tools` to `.mjs`.