### PR TITLE
Fix(data): re-enable the `ferry` question

### DIFF
--- a/data/transport/transport.publicodes
+++ b/data/transport/transport.publicodes
@@ -25,6 +25,7 @@ transport . empreinte:
       - train
       - métro ou tram
       - vacances
+      - ferry
 
 transport . vacances:
   mosaique:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"yaml": "^2.2.2"
 	},
 	"devDependencies": {
-		"@incubateur-ademe/publicodes-tools": "^0.2.0",
+		"@incubateur-ademe/publicodes-tools": "^0.2.1",
 		"@types/glob": "^8.1.0",
 		"cli-progress": "^3.11.2",
 		"deepl-node": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@incubateur-ademe/publicodes-tools@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.2.0.tgz#be9099fb7cdbbc7c7330e480669ad52d03a13186"
-  integrity sha512-hn1h540uWhh/A2O4KmffNG3wUDV1OjdtetRKZrS2jW06HQvuahqme8HClaxnqECcGyUikHPF/L+0fcMq5IE8rQ==
+"@incubateur-ademe/publicodes-tools@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.2.1.tgz#94585b3f07c6c054e6ffd7ef44081a4624b8a851"
+  integrity sha512-DFma9Jkwug7LQIGK1r8vjsmGZAc4m2EO8zbGF4DgCvFLe6fPz9ZpYAnLE9pisyS87AigxDgfRVm5UerFU9Be6g==
   dependencies:
     "@types/node" "^18.11.18"
     publicodes "^1.0.0-beta.71"


### PR DESCRIPTION
Re-enables the `ferry` question by using the patched `@incubateur-ademe/publicodes-tools` -- see: https://github.com/incubateur-ademe/publicodes-tools/pull/20

## Changelog

- Upgrade `@incubateur-ademe/publicodes-tools` to `v0.2.1`
- Re-enables the ferry question.