### PR TITLE
Feat(data): use `@incubateur-ademe/publicodes-commun`

### DIFF
--- a/data/alimentation/alimentation . boisson.publicodes
+++ b/data/alimentation/alimentation . boisson.publicodes
@@ -32,7 +32,7 @@ alimentation . boisson . chaude:
     A noter que vous pourrez sélectionner le type de lait que vous consommez dans une autre question !
 
     > Le café ou thé que vous consommez au petit déjeuner est à prendre en compte ici !
-  formule: par semaine * semaines par an
+  formule: par semaine * commun . semaines par an
   unité: kgCO2e
 
 alimentation . boisson . chaude . par semaine:
@@ -212,7 +212,7 @@ alimentation . boisson . eau en bouteille:
   formule: consommation annuelle * empreinte
 
 alimentation . boisson . eau en bouteille . consommation annuelle:
-  formule: jours par an * 1.5 l/jour
+  formule: commun . jours par an * 1.5 l/jour
   unité: l
   description: On considère que chacun boit 1,5 litres d'eau par jour.
 
@@ -241,7 +241,7 @@ alimentation . boisson . sucrées:
   description: |
     Notons que des alternatives au soda, très simples à préparer maison, sont possibles : c'est le cas du [kéfir](https://fr.wikipedia.org/wiki/K%C3%A9fir) ou [Kombucha](https://fr.wikipedia.org/wiki/Kombucha). Nous n'avons pas encore évalué les gains d'empreinte offerts par ces alternatives.
   unité: kgCO2e
-  formule: litres * semaines par an * facteur
+  formule: litres * commun . semaines par an * facteur
 
 alimentation . boisson . sucrées . facteur:
   formule:
@@ -291,7 +291,7 @@ alimentation . boisson . alcool:
     > Prenons l'exemple d'une 🍺 bière de 25cl : brassée au bout du monde, elle a voyagé des milliers de kilomètres et son contenu (la boisson) est emballé dans un contenant qui fait presque le même poids (200g de verre).
 
     > En privilégiant une bière brassée localement, servie à la pression (le fût étant réutilisé des années), on peut réduire drastiquement l'empreinte sans changer la consommation.
-  formule: litres * semaines par an * facteur
+  formule: litres * commun . semaines par an * facteur
 
 alimentation . boisson . alcool . facteur:
   formule:

--- a/data/alimentation/alimentation.publicodes
+++ b/data/alimentation/alimentation.publicodes
@@ -44,7 +44,7 @@ alimentation . laitages:
 alimentation . déjeuner et dîner:
   icônes: 🍽️
   titre: Déjeuners et dîners
-  formule: par semaine * semaines par an
+  formule: par semaine * commun . semaines par an
   unité: kgCO2e
 
 alimentation . déjeuner et dîner . par semaine:
@@ -376,7 +376,7 @@ alimentation . planétaire:
 alimentation . petit déjeuner annuel:
   titre: Petit déjeuner
   icônes: 🥐
-  formule: petit déjeuner * jours par an
+  formule: petit déjeuner * commun . jours par an
 
 alimentation . petit déjeuner . par semaine:
   titre: Empreinte hebdo petit déjeuner
@@ -616,7 +616,7 @@ alimentation . local . niveau:
     On applique un coefficient de 0,333 et 0,666 dans le cas où l'utilisateur indique qu'il consomme respectivement "parfois" ou "souvent" local.
 
 alimentation . local . part locale annuelle:
-  formule: part locale * semaines par an
+  formule: part locale * commun . semaines par an
 
 alimentation . local . part locale:
   unité: kgCO2e

--- a/data/commun.publicodes
+++ b/data/commun.publicodes
@@ -1,24 +1,10 @@
-intensité électricité:
-  titre: Intensité carbone du mix électrique français
-  description: Intensité moyenne, tous types de consommations confondues, année 2022.
-  formule: 0.0520
-  unité: kgCO2e/kWh
-  note: |
-    Ici, on parle du mix électrique de consommation. 
-    Le chiffre est issu de la Base Empreinte (Electricité/2022 - mix moyen/consommation) dont la méthodologie est décrite dans la [documentation](https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/).
-    La v2.6 de MicMac donnait une valeur de 12.4gCO2e/kWh pour les fournisseurs d'électricité "verte", mais cette valeur semble correspondre à un calcul théorique sur l'année, et non pas à un calcul réel, minute par minute.
-
-mois par an:
-  titre: Nombre de mois par an
-  formule: 12
-  unité: mois
-
-semaines par an:
-  titre: Nombre de semaines par an
-  formule: 52
-  unité: semaine
-
-jours par an:
-  titre: Nombre de jours par an
-  formule: 365
-  unité: jour
+importer!:
+  depuis:
+    nom: '@incubateur-ademe/publicodes-commun'
+    url: https://github.com/incubateur-ademe/publicodes-commun
+  dans: commun
+  les règles:
+    - intensité électricité
+    - mois par an
+    - semaines par an
+    - jours par an

--- a/data/conversion-métrique.publicodes
+++ b/data/conversion-métrique.publicodes
@@ -71,7 +71,12 @@ pétrole . litres gazole . voiture:
   unité: l
 
 pétrole . litres gazole . bus:
-  formule: part thermique * consommation . par tête * transport . bus . heures par semaine * semaines par an * transport . bus . vitesse
+  formule: |
+    part thermique
+    * consommation . par tête
+    * transport . bus . heures par semaine
+    * commun . semaines par an
+    * transport . bus . vitesse
   unité: l
 
 pétrole . litres gazole . bus . consommation . par tête:

--- a/data/divers/divers . animaux domestiques.publicodes
+++ b/data/divers/divers . animaux domestiques.publicodes
@@ -72,7 +72,7 @@ divers . animaux domestiques . empreinte . chats . empreinte:
       - litière
 
 divers . animaux domestiques . empreinte . chats . alimentation:
-  formule: besoin journalier nourriture * jours par an * empreinte nourriture
+  formule: besoin journalier nourriture * commun . jours par an * empreinte nourriture
   unité: kgCO2e
 
 divers . animaux domestiques . empreinte . chats . alimentation . empreinte nourriture:
@@ -261,7 +261,7 @@ divers . animaux domestiques . empreinte . gros chien . alimentation:
         chiens . alimentation . besoins énergétiques journaliers . facteur poids . taille chien: "'gros chien'"
 
 divers . animaux domestiques . empreinte . chiens . alimentation:
-  formule: besoin journalier nourriture * jours par an * empreinte nourriture
+  formule: besoin journalier nourriture * commun . jours par an * empreinte nourriture
   unité: kgCO2e
 
 divers . animaux domestiques . empreinte . chiens . alimentation . empreinte nourriture:

--- a/data/divers/divers . consommables.publicodes
+++ b/data/divers/divers . consommables.publicodes
@@ -1,6 +1,6 @@
 divers . produits consommables:
   icônes: 🧴
-  formule: empreinte par mois * mois par an
+  formule: empreinte par mois * commun . mois par an
   description: |
     L'objectif ici est de sortir de la question "dépenses" les produits consommables, qui ne sont donc pas amortis,
     au même titre que les achats "long terme" comme un instrument de musique. 

--- a/data/divers/divers . tabac.publicodes
+++ b/data/divers/divers . tabac.publicodes
@@ -16,7 +16,7 @@ divers . empreinte cigarette:
 
 divers . tabac . consommation:
   titre: Consommation annuelle de cigarettes
-  formule: consommation par semaine * nombre de cigarettes par paquet * semaines par an
+  formule: consommation par semaine * nombre de cigarettes par paquet * commun . semaines par an
   unité: cigarettes
 
 divers . tabac . consommation par semaine:

--- a/data/i18n/models/BE-en-us.yaml
+++ b/data/i18n/models/BE-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: BE
   nom: Belgium
   gentilé: Belgian
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Belgian electricity mix
   formule: 0.176
   note: |

--- a/data/i18n/models/BE-fr.yaml
+++ b/data/i18n/models/BE-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Belgique
   gentilé: belge
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique belge
   formule: 0.176
   note: |

--- a/data/i18n/models/CA-en-us.yaml
+++ b/data/i18n/models/CA-en-us.yaml
@@ -6,7 +6,7 @@ params:
     - nom: Alexandre Theve
       url: https://github.com/davidson-canada
 
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of Québec's electricity mix
   formule: 0.028
   note: |
@@ -40,7 +40,7 @@ transport . train . km:
     🚫🚃: 0
     Montréal ⇄ Québec: 250
     Montréal ⇄ Toronto: 500
-    
+
 services sociétaux:
   description: |
     > The calculation of the societal services footprint for Quebec is an attribution estimate based on data from the 2011 Canadian GHG emissions inventory

--- a/data/i18n/models/CA-fr.yaml
+++ b/data/i18n/models/CA-fr.yaml
@@ -6,7 +6,7 @@ params:
     - nom: Alexandre Theve
       url: https://github.com/davidson-canada
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique Québecois
   formule: 0.028
   note: |

--- a/data/i18n/models/CH-en-us.yaml
+++ b/data/i18n/models/CH-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: CH
   nom: Switzerland
   gentilé: Swiss
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Swiss electricity mix
   formule: 0.153
   note: |

--- a/data/i18n/models/CH-fr.yaml
+++ b/data/i18n/models/CH-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Suisse
   gentilé: suisse
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique suisse
   formule: 0.153
   note: |

--- a/data/i18n/models/DE-en-us.yaml
+++ b/data/i18n/models/DE-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: DE
   nom: Germany
   gentilé: German
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the German electricity mix
   formule: 0.48
   note: |

--- a/data/i18n/models/DE-fr.yaml
+++ b/data/i18n/models/DE-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Allemagne
   gentilé: allemande
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique allemand
   formule: 0.480
   note: |

--- a/data/i18n/models/GF-en-us.yaml
+++ b/data/i18n/models/GF-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: Guyana
   gentilé: Guyanese
   drapeau: FR
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Guyanese electricity mix
   formule: 0.957
   note: |

--- a/data/i18n/models/GF-fr.yaml
+++ b/data/i18n/models/GF-fr.yaml
@@ -5,7 +5,7 @@ params:
   gentilé: guyanaise
   drapeau: FR
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique guyanais
   formule: 0.957
   note: |

--- a/data/i18n/models/GP-en-us.yaml
+++ b/data/i18n/models/GP-en-us.yaml
@@ -8,7 +8,7 @@ params:
       url: https://nosgestesclimat.fr/à-propos
     - nom: on the initiative of MOLOKOÏ
       url: https://molokoi.com
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Guadeloupean electricity mix
   formule: 0.702
   note: |

--- a/data/i18n/models/GP-fr.yaml
+++ b/data/i18n/models/GP-fr.yaml
@@ -10,7 +10,7 @@ params:
     - nom: à l'initiative de MOLOKOÏ
       url: https://molokoi.com
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique guadeloupéen
   formule: 0.702
   note: |

--- a/data/i18n/models/IT-en-us.yaml
+++ b/data/i18n/models/IT-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: IT
   nom: Italy
   gentilé: Italian
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Italian electricity mix
   formule: 0.409
   note: |

--- a/data/i18n/models/IT-fr.yaml
+++ b/data/i18n/models/IT-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Italie
   gentilé: italienne
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique italien
   formule: 0.409
   note: |

--- a/data/i18n/models/LU-en-us.yaml
+++ b/data/i18n/models/LU-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: LU
   nom: Luxembourg
   gentilé: Luxembourgish
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Luxembourg electricity mix
   formule: 0.366
   note: |

--- a/data/i18n/models/LU-fr.yaml
+++ b/data/i18n/models/LU-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Luxembourg
   gentilé: luxembourgeoise
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique luxembourgeois
   formule: 0.366
   note: |

--- a/data/i18n/models/MQ-en-us.yaml
+++ b/data/i18n/models/MQ-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: Martinique
   gentilé: Martiniquaise
   drapeau: FR
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of Martinique's electricity mix
   formule: 0.84
   note: |

--- a/data/i18n/models/MQ-fr.yaml
+++ b/data/i18n/models/MQ-fr.yaml
@@ -5,7 +5,7 @@ params:
   gentilé: martiniquaise
   drapeau: FR
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique martiniquais
   formule: 0.840
   note: |

--- a/data/i18n/models/PF-en-us.yaml
+++ b/data/i18n/models/PF-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: French Polynesia
   gentilé: Polynesian
   drapeau: FR
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Polynesian electricity mix
   formule:
     moyenne:

--- a/data/i18n/models/PF-fr.yaml
+++ b/data/i18n/models/PF-fr.yaml
@@ -5,7 +5,7 @@ params:
   gentilé: polynésienne
   drapeau: FR
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique polynésien
   formule:
     moyenne:

--- a/data/i18n/models/PL-en-us.yaml
+++ b/data/i18n/models/PL-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: PL
   nom: Poland
   gentilé: Polish
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Polish electricity mix
   formule: 0.82
   note: |

--- a/data/i18n/models/PL-fr.yaml
+++ b/data/i18n/models/PL-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Pologne
   gentilé: polonaise
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique polonais
   formule: 0.820
   note: |

--- a/data/i18n/models/PT-en-us.yaml
+++ b/data/i18n/models/PT-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: PT
   nom: Portugal
   gentilé: Portuguese
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Portuguese electricity mix
   formule: 0.222
   note: |

--- a/data/i18n/models/PT-fr.yaml
+++ b/data/i18n/models/PT-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Portugal
   gentilé: portugaise
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique portugais
   formule: 0.222
   note: |

--- a/data/i18n/models/RE-en-us.yaml
+++ b/data/i18n/models/RE-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: Reunion Island
   gentilé: Reunionese #be careful to translation ("meeting")
   drapeau: FR
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of Reunion's electricity mix
   formule: 0.78
   note: |

--- a/data/i18n/models/RE-fr.yaml
+++ b/data/i18n/models/RE-fr.yaml
@@ -5,7 +5,7 @@ params:
   gentilé: réunionnaise
   drapeau: FR
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique réunionais
   formule: 0.780
   note: |

--- a/data/i18n/models/TN-en-us.yaml
+++ b/data/i18n/models/TN-en-us.yaml
@@ -5,7 +5,7 @@ params:
   authors:
     - nom: Nicolas Planchenault
       url: https://github.com/nicolaspkandeel
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Tunisian electricity mix
   formule: 0.453
   note: |

--- a/data/i18n/models/TN-fr.yaml
+++ b/data/i18n/models/TN-fr.yaml
@@ -6,7 +6,7 @@ params:
     - nom: Nicolas Planchenault
       url: https://github.com/nicolaspkandeel
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique tunisien
   formule: 0.453
   note: |

--- a/data/i18n/models/TR-en-us.yaml
+++ b/data/i18n/models/TR-en-us.yaml
@@ -2,7 +2,7 @@ params:
   code: TR
   nom: Turkey
   gentilé: Turkish
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the Turkish electricity mix
   formule: 0.393
   note: |

--- a/data/i18n/models/TR-fr.yaml
+++ b/data/i18n/models/TR-fr.yaml
@@ -3,7 +3,7 @@ params:
   nom: Turquie
   gentilé: turque
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique turc
   formule: 0.393
   note: |

--- a/data/i18n/models/UK-en-us.yaml
+++ b/data/i18n/models/UK-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: United Kingdom
   gentilé: English
   drapeau: GB
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of the United-Kingdom's electricity mix
   formule: 0.236
   note: |

--- a/data/i18n/models/UK-fr.yaml
+++ b/data/i18n/models/UK-fr.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: anglaise
   drapeau: GB
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique du Royaume-Uni
   formule: 0.236
   note: |

--- a/data/i18n/models/YT-en-us.yaml
+++ b/data/i18n/models/YT-en-us.yaml
@@ -3,7 +3,7 @@ params:
   nom: Mayotte
   gentilé: of Mayotte
   drapeau: FR
-intensité électricité:
+commun . intensité électricité:
   titre: Carbon intensity of Mayotte's electricity mix
   formule: 0.78
   note: |

--- a/data/i18n/models/YT-fr.yaml
+++ b/data/i18n/models/YT-fr.yaml
@@ -5,7 +5,7 @@ params:
   gentilé: de Mayotte
   drapeau: FR
 
-intensité électricité:
+commun . intensité électricité:
   titre: Intensité carbone du mix électrique de Mayotte
   formule: 0.780
   note: |

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -26002,10 +26002,6 @@ divers . numérique . appareils . montre connectée . empreinte:
   note: Emissions factor from Base Carbone
   note.auto: Emissions factor from Base Carbone
   note.lock: Facteur d'émissions issu de la Base Carbone
-jours par semaine:
-  titre: Number of days per week
-  titre.auto: Number of days per week
-  titre.lock: Nombre de jours par semaine
 divers . numérique . appareils . ordinateur fixe . tour:
   titre: Screen print
   titre.auto: Screen print

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -15153,10 +15153,25 @@ gaz . prix total:
   titre: total price
   titre.auto: total price
   titre.lock: prix total
-intensité électricité:
-  description: Average intensity, all types of consumption combined, year 2022.
-  description.auto: Average intensity, all types of consumption combined, year 2022.
-  description.lock: Intensité moyenne, tous types de consommations confondues, année 2022.
+commun . intensité électricité:
+  description: |-
+
+    > ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.
+
+
+    Average intensity, all types of consumption combined, year 2022.
+  description.auto: |-
+
+    > ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.
+
+
+    Average intensity, all types of consumption combined, year 2022.
+  description.lock: |-
+
+    > ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).
+
+
+    Intensité moyenne, tous types de consommations confondues, année 2022.
   note: |
     Here, we're talking about the electricity consumption mix. 
     The figure comes from the Empreinte Base (Electricity/2022 - average mix/consumption), whose methodology is described in the <a href="https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/">documentation</a>.
@@ -15172,10 +15187,13 @@ intensité électricité:
   titre: Carbon intensity of the French electricity mix
   titre.auto: Carbon intensity of the French electricity mix
   titre.lock: Intensité carbone du mix électrique français
-jours par an:
+commun . jours par an:
   titre: Number of days per year
   titre.auto: Number of days per year
   titre.lock: Nombre de jours par an
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
 logement:
   abréviation: hous.
   abréviation.auto: logmt.
@@ -17322,10 +17340,13 @@ logement . éteindre appareils . empreinte du foyer:
   titre: footprint of the home
   titre.auto: footprint of the home
   titre.lock: empreinte du foyer
-mois par an:
+commun . mois par an:
   titre: Number of months per year
   titre.auto: Number of months per year
   titre.lock: Nombre de mois par an
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
 parc français:
   description: |
     The objective of this small model is to estimate the average values associated with the dwelling (surface, surface heated with gas, consumption by heating...) to obtain a total average footprint of the dwelling which is representative of the average French person
@@ -17922,10 +17943,13 @@ pétrole . volume plein:
   titre: full volume
   titre.auto: full volume
   titre.lock: volume plein
-semaines par an:
+commun . semaines par an:
   titre: Number of weeks per year
   titre.auto: Number of weeks per year
   titre.lock: Nombre de semaines par an
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
 services marchands:
   abréviation: Market services
   abréviation.auto: Market services
@@ -21518,49 +21542,49 @@ logement . chauffage . bois . type . granulés . prix kWh:
   titre: price kWh
   titre.auto: price kWh
   titre.lock: prix kWh
-transport . ferry . empreinte du bateau:
+futureco-data . transport . ferry . empreinte du bateau:
   titre: Control boat footprint per km
   titre.auto: Control boat footprint per km
   titre.lock: Empreinte du bateau témoin par km
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We use the Mega Express Four from the Corsica Ferries fleet as a control boat. It is representative of large, fast ferries with max ~2000 passengers.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We use the Mega Express Four from the Corsica Ferries fleet as a control boat. It is representative of large, fast ferries with max ~2000 passengers.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Nous utilisons ici comme bateau témoin Méga Express Four de la flotte Corsica Ferries. Ils est représentatif des gros ferries de max ~2000 passagers, rapides.
-transport . ferry . empreinte totale . par km:
+futureco-data . transport . ferry . empreinte totale . par km:
   titre: per km
   titre.auto: per km
   titre.lock: par km
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . km par mille nautique:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . km par mille nautique:
   titre: km per nautical mile
   titre.auto: km per nautical mile
   titre.lock: km par mille nautique
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . empreinte par km volume:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . empreinte par km volume:
   titre: Footprint per km and passenger
   titre.auto: Footprint per km and passenger
   titre.lock: Empreinte par km et passager
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Here's our goal: to estimate the footprint of a passenger on passenger ferries such as those linking mainland France to Corsica and England.
@@ -21601,7 +21625,7 @@ transport . ferry . empreinte par km volume:
     See also this <a href="https://github.com/laem/futureco/issues/123">ticket</a> to read and contribute to the limits of the calculation.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Here's our goal: to estimate the footprint of a passenger on passenger ferries such as those linking mainland France to Corsica and England.
@@ -21642,7 +21666,7 @@ transport . ferry . empreinte par km volume:
     See also this <a href="https://github.com/laem/futureco/issues/123">ticket</a> to read and contribute to the limits of the calculation.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Voici notre objectif : estimer l'empreinte d'un passager sur les ferries de voyage comme ceux qui relient la métropole à la Corse et à l'Angleterre.
@@ -21681,46 +21705,46 @@ transport . ferry . empreinte par km volume:
     Évidemment, le calcul n'est donc applicable strictement qu'à ce bateau, mais nous faisons le choix de l'extrapoler comme un bateau type faute d'avoir les ressources pour modéliser chaque bateau commercial.
 
     Voir également ce [ticket](https://github.com/laem/futureco/issues/123) pour lire et contribuer aux limites du calcul.
-transport . ferry . empreinte totale:
+futureco-data . transport . ferry . empreinte totale:
   titre: total footprint
   titre.auto: total footprint
   titre.lock: empreinte totale
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . part du volume:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . part du volume:
   titre: Share of the useful volume of the boat attributed to the passenger
   titre.auto: Share of the useful volume of the boat attributed to the passenger
   titre.lock: Part du volume utile du bateau attribuée au passager
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . surface . communs:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . surface . communs:
   titre: common
   titre.auto: common
   titre.lock: communs
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     This includes staircases, seating in lounges other than bars or restaurants, and interior corridors. By convention, uncovered outdoor surfaces are not included, except for the obvious leisure areas: swimming pools and outdoor bars.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     This includes staircases, seating in lounges other than bars or restaurants, and interior corridors. By convention, uncovered outdoor surfaces are not included, except for the obvious leisure areas: swimming pools and outdoor bars.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Cela inclut les escaliers, des places assises en salon hors bar ou restaurant, les couloirs intérieurs. Par convention, on n'inclut pas les surfaces extérieures non couvertes, sauf les espaces de loisir évidents : la piscine et les bars extérieurs.
   question: What is the surface area of areas shared by all passengers?
   question.auto: What is the surface area of areas shared by all passengers?
   question.lock: Quelle est la surface des zones communes à tous les passagers ?
-transport . ferry . volume passager:
+futureco-data . transport . ferry . volume passager:
   titre: passenger volume
   titre.auto: passenger volume
   titre.lock: volume passager
@@ -21748,10 +21772,10 @@ transport . ferry . volume passager:
     La moyenne de remplissage de ces trois autres espaces doit davantage s'approcher d'un 2/3 avec une politique de prix au yield aggressive pour les places restantes. 
 
     ⚠️ C'est peut-être une hypothèse trop favorable qui pourrait donner lieu à une sous-estimation de 30% voir 100%.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . durée du voyage:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . durée du voyage:
   titre: travel time
   titre.auto: travel time
   titre.lock: durée du voyage
@@ -21769,7 +21793,7 @@ transport . ferry . durée du voyage:
     - 24h
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Indicate your departure and arrival times, making sure to select the day of arrival.
@@ -21777,7 +21801,7 @@ transport . ferry . durée du voyage:
     ⚠️ Speed is crucial for calculating the travel footprint, as fuel consumption varies with the cube of speed.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Indicate your departure and arrival times, making sure to select the day of arrival.
@@ -21785,7 +21809,7 @@ transport . ferry . durée du voyage:
     ⚠️ Speed is crucial for calculating the travel footprint, as fuel consumption varies with the cube of speed.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Indiquez votre heure de départ et d'arrivée, en sélectionnant bien le jour d'arrivée.
@@ -21797,32 +21821,32 @@ transport . ferry . durée du voyage:
   question: How long is your crossing?
   question.auto: How long is your crossing?
   question.lock: Quelle est la durée de votre traversée ?
-transport . ferry . volume garage:
+futureco-data . transport . ferry . volume garage:
   titre: garage volume
   titre.auto: garage volume
   titre.lock: volume garage
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . cabines nécessaires:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . cabines nécessaires:
   titre: cabins required
   titre.auto: cabins required
   titre.lock: cabines nécessaires
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     For the moment, we assume that there are only 4-seater cabins.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     For the moment, we assume that there are only 4-seater cabins.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     On part pour l'instant du principe qu'il n'y a que des cabines 4 places.
@@ -21832,7 +21856,7 @@ transport . ferry . cabines nécessaires:
     Here we would like to use a modulo mechanism, which does not exist in publi.codes.
   note.lock: |
     Ici on aimerait utiliser un mécanisme de modulo, qui n'existe pas dans publi.codes.
-transport . ferry . vitesse:
+futureco-data . transport . ferry . vitesse:
   titre: speed
   titre.auto: speed
   titre.lock: vitesse
@@ -21851,112 +21875,112 @@ transport . ferry . vitesse:
   question: How fast is the ferry?
   question.auto: How fast is the ferry?
   question.lock: Quelle est la vitesse du ferry ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . distance aller:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . distance aller:
   titre: distance one way
   titre.auto: distance one way
   titre.lock: distance aller
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We don't yet calculate the actual distances crossed by boats. So adding a 30% factor will help us get closer. 
     If you have access to a sourced average factor, please let us know.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We don't yet calculate the actual distances crossed by boats. So adding a 30% factor will help us get closer. 
     If you have access to a sourced average factor, please let us know.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Nous ne calculons pas encore les distances réelles traversées par les bateaux. Ainsi, l'ajout d'un facteur 30% permet de s'en rapprocher. 
     Si vous avez accès à un facteur moyen sourcé, n'hésitez pas à intervenir.
-transport . ferry . surface . garage:
+futureco-data . transport . ferry . surface . garage:
   titre: garage
   titre.auto: garage
   titre.lock: garage
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . surface . sièges:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . surface . sièges:
   titre: seats
   titre.auto: seats
   titre.lock: sièges
   question: What is the total surface area of the seats?
   question.auto: What is the total surface area of the seats?
   question.lock: Quelle est la surface totale des sièges ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . vitesse en kmh:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . vitesse en kmh:
   titre: speed in kmh
   titre.auto: speed in kmh
   titre.lock: vitesse en kmh
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . cabine partagée:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . cabine partagée:
   titre: shared cabin
   titre.auto: shared cabin
   titre.lock: cabine partagée
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . cabine:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . cabine:
   titre: cabin
   titre.auto: cabin
   titre.lock: cabine
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . rapport vitesse:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . rapport vitesse:
   titre: speed ratio
   titre.auto: speed ratio
   titre.lock: rapport vitesse
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . facteur vitesse:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . facteur vitesse:
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     It assumes a cubic evolution of power as a function of speed.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     It assumes a cubic evolution of power as a function of speed.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     On prend l'hypothèse d'une évolution au cube de la puissance en fonction de la vitesse.
   titre: speed factor
   titre.auto: speed factor
   titre.lock: facteur vitesse
-transport . ferry . surface . garage . haut:
+futureco-data . transport . ferry . surface . garage . haut:
   titre: top
   titre.auto: top
   titre.lock: haut
   question: What is the surface area of the boat's upper garage?
   question.auto: What is the surface area of the boat's upper garage?
   question.lock: Quelle est la surface de garage haut du bateau ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . voiture:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . voiture:
   titre: car
   titre.auto: car
   titre.lock: voiture
@@ -21966,13 +21990,13 @@ transport . ferry . volume passager . voiture:
     Here we decide not to see the car capacity and divide the car area by this number, because the different garage areas can accommodate both cars and trucks.
   note.lock: |
     Ici nous décidons de ne pas voir la capacité en voiture et diviser la surface voiture par ce nombre, car les différentes zones de garage peuvent accomoder aussi bien des voitures que des camions.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume utile:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume utile:
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Here, "useful volume" means the sum of all surfaces other than the boat's own infrastructure, safety, crew, etc.
@@ -21980,7 +22004,7 @@ transport . ferry . volume utile:
     > The calculation of the various surfaces is based on an<a href="https://futur.eco/ferry/surface-mega-express-four">SVG drawing</a> of the ship's decks, which we then use to deduce the volumes
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Here, "useful volume" means the sum of all surfaces other than the boat's own infrastructure, safety, crew, etc.
@@ -21988,7 +22012,7 @@ transport . ferry . volume utile:
     > The calculation of the various surfaces is based on an<a href="https://futur.eco/ferry/surface-mega-express-four">SVG drawing</a> of the ship's decks, which we then use to deduce the volumes
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     On appelle ici volume utile la somme de toutes les surfaces qui ne sont pas l'infrastructure elle-même du bateau, sa sécurité, son équipage, etc.
@@ -22000,16 +22024,16 @@ transport . ferry . volume utile:
   titre: useful volume
   titre.auto: useful volume
   titre.lock: volume utile
-transport . ferry . cabine . nombre:
+futureco-data . transport . ferry . cabine . nombre:
   titre: number
   titre.auto: number
   titre.lock: nombre
   question: What is the total number of passenger cabins?
   question.auto: What is the total number of passenger cabins?
   question.lock: Quel est le nombre total de cabines passager ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 transport . ferry . heures:
   titre: Ferry hours in the year
   titre.auto: Ferry hours in the year
@@ -22071,7 +22095,7 @@ transport . ferry . heures:
       - et bien sûr la vitesse du bateau (plus un bateau est rapide, plus il consomme).
 
     Le calcul est donc fait pour une traversée type.
-transport . ferry . groupe:
+futureco-data . transport . ferry . groupe:
   suggestions:
     - only
     - in couple
@@ -22093,16 +22117,16 @@ transport . ferry . groupe:
   question: How much do you travel?
   question.auto: How much do you travel?
   question.lock: À combien voyagez-vous ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . consommation de services:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . consommation de services:
   titre: consumption of services
   titre.auto: consumption of services
   titre.lock: consommation de services
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   question: Do you use the ferry's ancillary services (bar, restaurant, swimming pool, etc.)?
   question.auto: Do you use the ferry's ancillary services (bar, restaurant, swimming pool, etc.)?
   question.lock: Utilisez vous les services accessoires du ferry (bar, restaurant, piscine, etc.) ?
@@ -22137,25 +22161,25 @@ transport . ferry . présent:
     Si vous ne prenez pas le ferry tous les ans, mais que vous comptez continuer à le prendre, répondez "oui" et estimez grossièrement le nombre d'heures ramené à l'année.
 
     Par exemple pour une traversée de 9h (une nuit) tous les 3 ans, répondez `3`.
-transport . ferry . cabine:
+futureco-data . transport . ferry . cabine:
   note: There are also shared cabins (like in night trains), we can add them later as a possible option.
   note.auto: There are also shared cabins (like in night trains), we can add them later as a possible option.
   note.lock: Il existe aussi des cabines partagées (comme dans les trains de nuit), nous pourrons les ajouter par la suite comme une option possible.
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Unsurprisingly, cabin travel brings comfort, but at the expense of on-board weight.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Unsurprisingly, cabin travel brings comfort, but at the expense of on-board weight.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Sans surprise, voyager en cabine apporte du confort mais en contrepartie du poids embarqué.
@@ -22165,51 +22189,51 @@ transport . ferry . cabine:
   question: Did you take a cabin (rather than a single seat)?
   question.auto: Did you take a cabin (rather than a single seat)?
   question.lock: Avez-vous pris une cabine (plutôt qu'un simple siège) ?
-transport . ferry . correction temps de navigation:
+futureco-data . transport . ferry . correction temps de navigation:
   titre: navigation time correction
   titre.auto: navigation time correction
   titre.lock: correction temps de navigation
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The power required to propel a ship is the cube of its speed. The climate footprint per hour naturally follows this same function. But the ship is then going faster: it will emit more per hour for less time, so this factor corrects for.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The power required to propel a ship is the cube of its speed. The climate footprint per hour naturally follows this same function. But the ship is then going faster: it will emit more per hour for less time, so this factor corrects for.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     La puissance nécessaire pour faire avancer le navire évolue au cube de la vitesse. L'empreinte climat par heure suite naturellement cette même fonction. Mais le navire va alors plus vite : il va émettre plus à l'heure pendant moins de temps, ce facteur corrige le tir pour.
-transport . ferry . volume passager . voiture . longueur:
+futureco-data . transport . ferry . volume passager . voiture . longueur:
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We take the length defined here https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture, with a smaller mark-up than the width, as it is dynamic (the width is fixed by floor bollards) and does not need to accommodate two competing open doors.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We take the length defined here https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture, with a smaller mark-up than the width, as it is dynamic (the width is fixed by floor bollards) and does not need to accommodate two competing open doors.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Nous prenons la longueur définie ici https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture, avec une majoration moins importante que la largeur, car elle est dynamique (la largeur est fixée par des bornes au sol) et ne nécessite pas d'accomoder deux portières ouvertes en concurrence.
   titre: length
   titre.auto: length
   titre.lock: longueur
-transport . ferry . vitesse moyenne . métrique:
+futureco-data . transport . ferry . vitesse moyenne . métrique:
   note: |
     We consider the average speed of the Mega Express Four of Corsica Ferries
     Greenferries 2019 data from Thetis-MRV 2019 https://www.greenferries.org/ships/mega-express-four-9086590/
@@ -22222,10 +22246,10 @@ transport . ferry . vitesse moyenne . métrique:
   titre: Average ferry speed
   titre.auto: Average ferry speed
   titre.lock: Vitesse moyenne ferry
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . empreinte totale moyenne:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . empreinte totale moyenne:
   titre: average total footprint
   titre.auto: average total footprint
   titre.lock: empreinte totale moyenne
@@ -22235,16 +22259,16 @@ transport . ferry . empreinte totale moyenne:
     Greenferries 2020 data from Thetis-MRV 2020 https://mrv.emsa.europa.eu/#public/emission-report
   note.lock: |
     Données greenferries 2020 tirées de Thetis-MRV 2020 https://mrv.emsa.europa.eu/#public/emission-report
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . voiture:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . voiture:
   titre: car
   titre.auto: car
   titre.lock: voiture
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
 
@@ -22255,7 +22279,7 @@ transport . ferry . voiture:
     If you're transporting a motorcycle, answer no (the footprint will be slightly underestimated).
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
 
@@ -22266,7 +22290,7 @@ transport . ferry . voiture:
     If you're transporting a motorcycle, answer no (the footprint will be slightly underestimated).
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
 
@@ -22278,10 +22302,10 @@ transport . ferry . voiture:
   question: Are you transporting your car?
   question.auto: Are you transporting your car?
   question.lock: Transportez-vous votre voiture ?
-transport . ferry . durée du voyage . réelle:
+futureco-data . transport . ferry . durée du voyage . réelle:
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We consider that for a departure at 7pm on the ticket, and an arrival at 7am, for the calculation of speed the crossing did not last 12h but 11h, because there are 30 minutes before the ferry starts and then 30 minutes of disembarkation. Of course, this may vary depending on the company and the type of ticket (pedestrian or car boarding), but it's an order of magnitude.
@@ -22289,7 +22313,7 @@ transport . ferry . durée du voyage . réelle:
     For short crossings of less than 3 hours, we deduct 10% of the time (also by convention), i.e. 20 minutes * 2 for 3 hours, for example.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We consider that for a departure at 7pm on the ticket, and an arrival at 7am, for the calculation of speed the crossing did not last 12h but 11h, because there are 30 minutes before the ferry starts and then 30 minutes of disembarkation. Of course, this may vary depending on the company and the type of ticket (pedestrian or car boarding), but it's an order of magnitude.
@@ -22297,7 +22321,7 @@ transport . ferry . durée du voyage . réelle:
     For short crossings of less than 3 hours, we deduct 10% of the time (also by convention), i.e. 20 minutes * 2 for 3 hours, for example.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Nous considérons que pour un départ à 19h sur le billet, et une arrivée à 7h, pour le calcul de la vitesse la traversée n'a pas duré 12h de navigation mais 11h, car il y a 30 minutes avant que le ferry se lance puis 30 minutes de débarquement. Cela peut évidemment varier en fonction des compagnies et du type de billet (embarquement piéton ou avec voiture), mais c'est un ordre de grandeur.
@@ -22306,7 +22330,7 @@ transport . ferry . durée du voyage . réelle:
   titre: real
   titre.auto: real
   titre.lock: réelle
-transport . ferry . distance aller . orthodromique:
+futureco-data . transport . ferry . distance aller . orthodromique:
   suggestions:
     - 🇬🇧 Cherbourg↔Poole
     - 🏝️ Marseille↔Ajaccio
@@ -22324,7 +22348,7 @@ transport . ferry . distance aller . orthodromique:
   titre.lock: orthodromique
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Enter the departure and arrival city of a real ferry journey.
@@ -22332,7 +22356,7 @@ transport . ferry . distance aller . orthodromique:
     We do not yet support the estimation of the climate footprint of a multimodal journey (TGV + ferry, for example).
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Enter the departure and arrival city of a real ferry journey.
@@ -22340,7 +22364,7 @@ transport . ferry . distance aller . orthodromique:
     We do not yet support the estimation of the climate footprint of a multimodal journey (TGV + ferry, for example).
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Saisissez la ville de départ et d'arrivée d'un vrai trajet en ferry.
@@ -22352,20 +22376,20 @@ transport . ferry . distance aller . orthodromique:
   question: What's your route?
   question.auto: What's your route?
   question.lock: Quel est votre trajet ?
-transport . ferry . hauteur pont bas:
+futureco-data . transport . ferry . hauteur pont bas:
   titre: low bridge height
   titre.auto: low bridge height
   titre.lock: hauteur pont bas
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . passagers:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . passagers:
   titre: Average passengers
   titre.auto: Average passengers
   titre.lock: Passagers moyens
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     For some public services, we need to distribute the weight per passenger.
@@ -22373,7 +22397,7 @@ transport . ferry . passagers:
     This is the Mega Express Four value https://fr.wikipedia.org/wiki/Mega_Express_Four but in order of magnitude of the average value, obtained thanks to Thetis-MRV declarations exposed on https://www.greenferries.org/ships/mega-express-four-9086590 in 2018-2019, therefore pre-pandemic.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     For some public services, we need to distribute the weight per passenger.
@@ -22381,7 +22405,7 @@ transport . ferry . passagers:
     This is the Mega Express Four value https://fr.wikipedia.org/wiki/Mega_Express_Four but in order of magnitude of the average value, obtained thanks to Thetis-MRV declarations exposed on https://www.greenferries.org/ships/mega-express-four-9086590 in 2018-2019, therefore pre-pandemic.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Pour certaines services en commun, nous avons besoin de répartir le poids par passager.
@@ -22393,166 +22417,166 @@ transport . ferry . passagers:
     This parameter is very important. The maximum number of passengers of the Mega Express Four is 1880 according to Wikipedia. It runs at 1/3 of its capacity, which is very low compared to the TGV or airliners.
   note.lock: |
     Ce paramètre est très déterminant. Le nombre de passagers max du Mega Express Four est de 1880 d'après Wikipedia. Il circule donc à 1/3 de son remplissage, ce qui est très faible si on compare au TGV ou aux avions de ligne.
-transport . ferry . surface . siège:
+futureco-data . transport . ferry . surface . siège:
   titre: headquarters
   titre.auto: headquarters
   titre.lock: siège
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . hauteur pont haut:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . hauteur pont haut:
   titre: height of high bridge
   titre.auto: height of high bridge
   titre.lock: hauteur pont haut
   note: We are simplifying these data for the moment, but they can be improved later.
   note.auto: We are simplifying these data for the moment, but they can be improved later.
   note.lock: Nous simplifions pour l'instant ces données qui pourront être améliorées dans un second temps.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . voiture . majoré:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . voiture . majoré:
   note: We assume that some cars park in a garage with a high deck height, so let's apply the area-weighted average.
   note.auto: We assume that some cars park in a garage with a high deck height, so let's apply the area-weighted average.
   note.lock: Nous partons du principe que certaines voitures se garent dans un garage dont la hauteur du pont haut, donc appliquons la moyenne pondérée par la surface.
   titre: Car garage volume
   titre.auto: Car garage volume
   titre.lock: Volume garage voiture
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . surface . garage . bas:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . surface . garage . bas:
   titre: bottom
   titre.auto: bottom
   titre.lock: bas
   question: What is the surface area of the boat's lower garage?
   question.auto: What is the surface area of the boat's lower garage?
   question.lock: Quelle est la surface de garage bas du bateau ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . loisirs:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . loisirs:
   titre: leisure
   titre.auto: leisure
   titre.lock: loisirs
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . vitesse moyenne:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . vitesse moyenne:
   titre: average speed
   titre.auto: average speed
   titre.lock: vitesse moyenne
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . voiture . largeur:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . voiture . largeur:
   titre: width
   titre.auto: width
   titre.lock: largeur
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We take the dimensions recommended here for a standard parking lot https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture/
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We take the dimensions recommended here for a standard parking lot https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture/
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Nous prenons les dimensions conseillées ici pour un parking standard https://parkinggarage.fr/dimension-standard-longueur-largeur-hauteur-parking-box-garage-voiture/
-transport . ferry . hauteur moyenne garage:
+futureco-data . transport . ferry . hauteur moyenne garage:
   titre: average garage height
   titre.auto: average garage height
   titre.lock: hauteur moyenne garage
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume communs:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume communs:
   titre: common volumes
   titre.auto: common volumes
   titre.lock: volume communs
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . surface . loisirs:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . surface . loisirs:
   titre: leisure
   titre.auto: leisure
   titre.lock: loisirs
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Restaurants, bars, lounges, games, shops, swimming pools, etc.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Restaurants, bars, lounges, games, shops, swimming pools, etc.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Restaurants, bars, salons, jeux, commerces, piscines, etc.
   question: How much space is dedicated to leisure activities?
   question.auto: How much space is dedicated to leisure activities?
   question.lock: Quelle est la surface dédiée aux loisirs ?
-transport . ferry . surface . cabine:
+futureco-data . transport . ferry . surface . cabine:
   titre: cabin
   titre.auto: cabin
   titre.lock: cabine
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . billet cabine:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . billet cabine:
   titre: cabin ticket
   titre.auto: cabin ticket
   titre.lock: billet cabine
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . siège . nombre:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . siège . nombre:
   titre: number
   titre.auto: number
   titre.lock: nombre
   question: What is the total number of passenger seats?
   question.auto: What is the total number of passenger seats?
   question.lock: Quel est le nombre total de sièges passager ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . surface . cabines:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . surface . cabines:
   titre: cabins
   titre.auto: cabins
   titre.lock: cabines
   question: What is the total surface area of the cabins?
   question.auto: What is the total surface area of the cabins?
   question.lock: Quelle est la surface totale des cabines ?
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . communs:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . communs:
   titre: common
   titre.auto: common
   titre.lock: communs
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
-transport . ferry . volume passager . siège:
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+futureco-data . transport . ferry . volume passager . siège:
   titre: A seat in a dormitory
   titre.auto: A seat in a dormitory
   titre.lock: Un siège dans un dortoir
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . vacances:
   titre: Weekend or vacation nights
   titre.auto: Weekend or vacation nights
@@ -23864,16 +23888,16 @@ logement . piscine . construction . terrassement:
   titre: landscaping
   titre.auto: landscaping
   titre.lock: terrassement
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . équipement nautique:
   titre: nautical equipment
   titre.auto: nautical equipment
   titre.lock: équipement nautique
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We consider the skimmer, the lamp, the suction inlet, the "technical" box, the 10m hose for the brush.
@@ -23881,7 +23905,7 @@ logement . piscine . construction . équipement nautique:
     All this is simplified to 20kg of HDPE PVC, i.e. 45kgCO2e
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     We consider the skimmer, the lamp, the suction inlet, the "technical" box, the 10m hose for the brush.
@@ -23889,7 +23913,7 @@ logement . piscine . construction . équipement nautique:
     All this is simplified to 20kg of HDPE PVC, i.e. 45kgCO2e
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     On considère le skimmer, la lampe, la prise d'aspiration , le coffre "technique" entérré , le tuyau de 10m pour la brosse balai.
@@ -23899,30 +23923,30 @@ logement . piscine . construction . béton . type . volume:
   titre: volume
   titre.auto: volume
   titre.lock: volume
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . étanchéité:
   titre: sealing
   titre.auto: sealing
   titre.lock: étanchéité
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . béton . masse volumique:
   titre: density
   titre.auto: density
   titre.lock: masse volumique
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . lot technique:
   titre: technical package
   titre.auto: technical package
   titre.lock: lot technique
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . traitement chimique:
   titre: chemical treatment
   titre.auto: chemical treatment
@@ -23939,35 +23963,35 @@ logement . piscine . traitement chimique:
     Sur la base d'hypothèses sourcées dans les références de la variable "masse de chlore", pour l'instant dans le but d'obtenir un premier ordre de grandeur, on assimile toutes les matières chimiques utilisées dans une piscine au chlore.
 
     On ignore aussi le transport du chlore acheté, en pratique souvent en voiture, ce qui implique une consommation d'essence non négligeable mais de second ordre a priori.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction:
   titre: construction
   titre.auto: construction
   titre.lock: construction
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . abri:
   titre: shelter
   titre.auto: shelter
   titre.lock: abri
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     To be implemented, you can ask a question if it's safe to do so, but you have to take into account the gains in heating and filtering.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     To be implemented, you can ask a question if it's safe to do so, but you have to take into account the gains in heating and filtering.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     A implémenter, on pourra alors poser une question si abri, mais il faudra prendre en compte les gains en chauffage et filtrage.
@@ -23981,63 +24005,63 @@ logement . piscine . construction . durée de vie:
     We initially took this estimate, which seems a little low for the concrete (which is estimated to last more like 40 years), but rather realistic for the rest of the equipment. It's a parameter that can be modified if necessary.
   note.lock: |
     Nous avons dans un premier temps pris cette estimation, qui semble un peu basse pour le béton (qui est estimé davantage à 40 ans), mais plutôt réaliste pour le reste des équipements. C'est un paramètre à faire évoluer au besoin.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . divers chantier:
   titre: various worksites
   titre.auto: various worksites
   titre.lock: divers chantier
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . béton . type . épaisseur:
   titre: thickness
   titre.auto: thickness
   titre.lock: épaisseur
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . béton . type . volume parallélépipède:
   titre: parallelepiped volume
   titre.auto: parallelepiped volume
   titre.lock: volume parallélépipède
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . béton . empreinte:
   titre: footprint
   titre.auto: footprint
   titre.lock: empreinte
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . béton . masse:
   titre: mass
   titre.auto: mass
   titre.lock: masse
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . plage pierre:
   titre: Stone beach
   titre.auto: Stone beach
   titre.lock: Plage en pierre
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The beach is the area around the pool where people walk barefoot and lounge in deckchairs.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The beach is the area around the pool where people walk barefoot and lounge in deckchairs.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     La plage est la zone autour de la piscine où l'on marche pieds nus et où l'on se prélasse dans des transats.
@@ -24045,16 +24069,16 @@ logement . piscine . construction . béton:
   titre: concrete
   titre.auto: concrete
   titre.lock: béton
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . masse de chlore:
   titre: chlorine mass
   titre.auto: chlorine mass
   titre.lock: masse de chlore
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     > If you opt for a chlorine treatment, you will need to count on an annual budget of approximately €150 for chlorine, €20 for flocculant, €30 for an anti-scale product and €30 for a product to rebalance the pH, which corresponds to an annual budget of approximately €230
@@ -24068,7 +24092,7 @@ logement . piscine . masse de chlore:
     The result calculated here has an order of magnitude consistent with that given in <a href="https://cote-piscine-mag.com/combien-coute-le-traitement-piscine/">this article</a>, ~ 20 kg.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     > If you opt for a chlorine treatment, you will need to count on an annual budget of approximately €150 for chlorine, €20 for flocculant, €30 for an anti-scale product and €30 for a product to rebalance the pH, which corresponds to an annual budget of approximately €230
@@ -24082,7 +24106,7 @@ logement . piscine . masse de chlore:
     The result calculated here has an order of magnitude consistent with that given in <a href="https://cote-piscine-mag.com/combien-coute-le-traitement-piscine/">this article</a>, ~ 20 kg.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     > Si vous optez pour un traitement au chlore, vous devrez compter sur un budget annuel d’environ 150 € de chlore, 20 € de produit floculant, 30 € de produit anticalcaire, et enfin 30 € de produit pour rééquilibrer le pH, ce qui correspond à un budget annuel d’environ 230 €
@@ -24098,35 +24122,35 @@ logement . piscine . construction . béton . type . masse:
   titre: mass
   titre.auto: mass
   titre.lock: masse
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . type . surface . murs:
   titre: walls
   titre.auto: walls
   titre.lock: murs
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . type . surface:
   titre: surface
   titre.auto: surface
   titre.lock: surface
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The area of the pool actually built is used as the basis for this model.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The area of the pool actually built is used as the basis for this model.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     La surface de la piscine réellement construite et utilisée comme base pour ce modèle.
@@ -24134,16 +24158,16 @@ logement . piscine . construction . béton . type . volume plage:
   titre: volume range
   titre.auto: volume range
   titre.lock: volume plage
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . étanchéité . liner . quantité:
   titre: quantity
   titre.auto: quantity
   titre.lock: quantité
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . profondeur:
   titre: depth
   titre.auto: depth
@@ -24151,30 +24175,30 @@ logement . piscine . profondeur:
   note: We assume an average water depth of 1.50 m, for example, with a linear slope of 1 m to 2 m.
   note.auto: We assume an average water depth of 1.50 m, for example, with a linear slope of 1 m to 2 m.
   note.lock: Nous partons sur une profondeur moyenne d'eau de 1m50, par exemple une pente linéaire de 1m à 2m.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . surface plage:
   titre: beach surface
   titre.auto: beach surface
   titre.lock: surface plage
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . volume:
   titre: volume
   titre.auto: volume
   titre.lock: volume
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . empreinte pierre:
   titre: stone imprint
   titre.auto: stone imprint
   titre.lock: empreinte pierre
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . empreinte chlore:
   titre: chlorine footprint
   titre.auto: chlorine footprint
@@ -24182,30 +24206,30 @@ logement . piscine . empreinte chlore:
   note: We take the example of Cl2, liquefied chlorine gas, in the reference document below.
   note.auto: We take the example of Cl2, liquefied chlorine gas, in the reference document below.
   note.lock: Nous prenons l'empreinte du Cl2, chlore gazeux liquéfié dans le document en référence ci-dessous.
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . étanchéité . liner:
   titre: liner
   titre.auto: liner
   titre.lock: liner
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . étanchéité . liner . empreinte PVC:
   titre: pVC footprint
   titre.auto: pVC footprint
   titre.lock: empreinte PVC
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . empreinte empirique:
   titre: empirical footprint
   titre.auto: empirical footprint
   titre.lock: empreinte empirique
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   note: |
     The figures in this namespace come mainly from the calculation <a href="https://user-images.githubusercontent.com/1177762/245216468-760f16f8-59f4-447f-a1e5-862fcdb08980.png">presented on this A4 sheet</a>.
   note.auto: |
@@ -24216,23 +24240,23 @@ logement . piscine . empreinte eau froide:
   titre: cold water footprint
   titre.auto: cold water footprint
   titre.lock: empreinte eau froide
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . lot technique . pompe:
   titre: pump
   titre.auto: pump
   titre.lock: pompe
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . maçonnerie:
   titre: masonry
   titre.auto: masonry
   titre.lock: maçonnerie
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine:
   titre: pool
   titre.auto: pool
@@ -24318,38 +24342,38 @@ logement . piscine . construction . terrassement . conso diesel . pelleteuse:
   titre.lock: pelleteuse
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     9t backhoe
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     9t backhoe
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Pelleteuse de 9t
 logement . piscine . construction . terrassement . conso diesel . chargeuse:
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     3t loader
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     3t loader
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Chargeuse de 3t
@@ -24359,19 +24383,19 @@ logement . piscine . construction . terrassement . conso diesel . chargeuse:
 logement . piscine . construction . lot technique . hydraulique:
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Pipes from pool to pump, control equipment.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Pipes from pool to pump, control equipment.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Les tuyaux de la piscine à la pompe, le matériel de régulation.
@@ -24382,9 +24406,9 @@ logement . piscine . correcteur surface type:
   titre: surface corrector type
   titre.auto: surface corrector type
   titre.lock: correcteur surface type
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . présent:
   titre: present
   titre.auto: present
@@ -24414,28 +24438,28 @@ logement . piscine . construction . divers chantier . gasoil:
   titre: diesel
   titre.auto: diesel
   titre.lock: gasoil
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . lot technique . électricité:
   titre: electricity
   titre.auto: electricity
   titre.lock: électricité
   description: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The terminal block, the pipes, the electric cable (20m), the sheath.
   description.auto: |-
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     The terminal block, the pipes, the electric cable (20m), the sheath.
   description.lock: |-
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     Le bornier, les tuyaux, le cable électrique (20m), la gaine.
@@ -24460,19 +24484,19 @@ logement . piscine . surface:
   question.lock: Quelle est la taille de votre piscine ?
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     💡 Don't forget to include **the pool's energy consumption in those of your home**. If your pool is heated, your bill should be greatly affected!
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     💡 Don't forget to include **the pool's energy consumption in those of your home**. If your pool is heated, your bill should be greatly affected!
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     💡 Pensez à prendre en compte **les consommations d'énergie de la piscine dans celles de votre logement**. Votre facture devrait d'ailleurs être fortement impactée si votre piscine est chauffée !
@@ -24489,37 +24513,37 @@ logement . piscine . construction . divers chantier . livraison:
   titre: delivery
   titre.auto: delivery
   titre.lock: livraison
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . étanchéité . liner . durée de vie:
   titre: Liner lifetime
   titre.auto: Liner lifetime
   titre.lock: Durée de vie du liner
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . terrassement . empreinte diesel:
   titre: diesel footprint
   titre.auto: diesel footprint
   titre.lock: empreinte diesel
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . divers chantier . consommable:
   titre: consumables
   titre.auto: consumables
   titre.lock: consommable
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . type . surface . parallélépipède:
   titre: parallelepiped
   titre.auto: parallelepiped
   titre.lock: parallélépipède
   description: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Consider a pool measuring 8m x 4m x an average depth of 1.5m (2 at one end and 1 at the other, linear descent).
@@ -24527,7 +24551,7 @@ logement . piscine . type . surface . parallélépipède:
     The surface area of this typical pool is 32m² of bottom and 36m² of walls.
   description.auto: |
 
-    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.
+    > ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.
 
 
     Consider a pool measuring 8m x 4m x an average depth of 1.5m (2 at one end and 1 at the other, linear descent).
@@ -24535,7 +24559,7 @@ logement . piscine . type . surface . parallélépipède:
     The surface area of this typical pool is 32m² of bottom and 36m² of walls.
   description.lock: |
 
-    > ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).
+    > ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).
 
 
     On considère une piscine de 8m x 4m x une profondeur moyenne de 1,5m (2 au bout et 1 à l'autre bout, descente linéaire).
@@ -24545,16 +24569,16 @@ logement . piscine . construction . étanchéité . liner . surface:
   titre: surface
   titre.auto: surface
   titre.lock: surface
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 logement . piscine . construction . terrassement . conso diesel:
   titre: diesel consumption
   titre.auto: diesel consumption
   titre.lock: conso diesel
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
 divers . tabac . nombre de cigarettes par paquet:
   titre: number of cigarettes per pack
   titre.auto: number of cigarettes per pack
@@ -25499,23 +25523,23 @@ divers . loisirs . culture . musées et monuments . proportion de visiteurs:
     Ce chiffre est différent de celui que l'on retrouve en sommant les visiteurs occasionnels et amateurs (qui excluent peut-être les visiteurs d'expositions temporaires).
     De plus, il concerne les personnes de plus de 18 ans. On a donc un léger biais ici.
 logement . eau . impact par litre froid:
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   titre: impact by cold liter
   titre.auto: impact by cold liter
   titre.lock: impact par litre froid
 logement . eau . impact par litre froid . traitement eau usée:
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   titre: wastewater treatment
   titre.auto: wastewater treatment
   titre.lock: traitement eau usée
 logement . eau . impact par litre froid . eau potable:
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   titre: drinking water
   titre.auto: drinking water
   titre.lock: eau potable
@@ -25573,10 +25597,10 @@ alimentation . une semaine chocolat chaud végétalien:
   titre: a week of vegan hot chocolate
   titre.auto: a week of vegan hot chocolate
   titre.lock: une semaine chocolat chaud végétalien
-transport . ferry . surface:
+futureco-data . transport . ferry . surface:
   titre: surface
   titre.auto: surface
   titre.lock: surface
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -25923,9 +25923,6 @@ futureco-data . transport . ferry . surface:
   titre: surface
   titre.auto: surface
   titre.lock: surface
-  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
   description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'
@@ -26102,3 +26099,10 @@ logement . climatisation . fuite fin de vie amortie:
   titre: End-of-life air conditioner leakage footprint
   titre.auto: End-of-life air conditioner leakage footprint
   titre.lock: Empreinte des fuites de fin de vie du climatiseur
+commun . jours par semaine:
+  titre: Number of days per week
+  titre.auto: Number of days per week
+  titre.lock: Nombre de jours par semaine
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'

--- a/data/logement/actions/logement.publicodes
+++ b/data/logement/actions/logement.publicodes
@@ -242,8 +242,6 @@ logement . séchage air libre:
   note: |
     400 kWh est une valeur choisie sur la base des kWh annuels donnés par différents constructeurs, les valeurs allant de 300 à 500+ kWh annum, 400 kWh a été retenu.
 
-logement . climatisation:
-
 logement . climatisation . réduction:
   titre: Limiter ma climatisation
   icônes: ❄️✋

--- a/data/logement/actions/logement.publicodes
+++ b/data/logement/actions/logement.publicodes
@@ -112,7 +112,7 @@ logement . éteindre appareils:
     Source : ADEME - [Réduire sa facture d'électricité](https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-reduire-facture-electricite.pdf), page 18.
 
 logement . éteindre appareils . empreinte du foyer:
-  formule: énergie de veille * intensité électricité
+  formule: énergie de veille * commun . intensité électricité
 
 logement . énergie de veille:
   formule: puissance * temps d'absence
@@ -129,7 +129,7 @@ logement . énergie de veille . puissance:
 
   unité: kW
 logement . énergie de veille . temps d'absence:
-  formule: jours par an * journalier
+  formule: commun . jours par an * journalier
   unité: h
 logement . énergie de veille . temps d'absence . journalier:
   formule: 12

--- a/data/logement/logement.publicodes
+++ b/data/logement/logement.publicodes
@@ -226,7 +226,7 @@ logement . électricité . estimation via le coût:
     Eurostat household second half 2021: https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics
 
 logement . électricité . intensité carbone:
-  formule: intensité électricité
+  formule: commun . intensité électricité
   unité: kgCO2e/kWh
   description: |
     Nous utilisons ici l'empreinte moyenne du mix de la région de simulation.

--- a/data/numérique/actions/numérique.publicodes
+++ b/data/numérique/actions/numérique.publicodes
@@ -9,7 +9,7 @@ divers . numérique . internet . diminuer:
 
     En limiter sa consommation, ici d'une heure par jour quand on y passe plus de 2h, et privilégier des alternatives comme la lecture permet de réduire son empreinte carbone numérique.
 divers . numérique . internet . empreinte réduite:
-  formule: empreinte horaire * durée journalière . réduction * jours par an
+  formule: empreinte horaire * durée journalière . réduction * commun . jours par an
 divers . numérique . internet . durée journalière . réduction:
   formule: 1
   description: Nous proposons ici de réduire d'une heure le temps passé à regarder des vidéos en ligne.

--- a/data/numérique/numérique.publicodes
+++ b/data/numérique/numérique.publicodes
@@ -14,7 +14,7 @@ divers . numérique:
 
 divers . numérique . internet:
   icônes: 🌐
-  formule: empreinte horaire * durée journalière * jours par an
+  formule: empreinte horaire * durée journalière * commun . jours par an
   unité: kgCO2e
 divers . numérique . internet . consommation horaire:
   formule:
@@ -39,7 +39,7 @@ divers . numérique . internet . consommation horaire:
   références:
     - https://www.carbonbrief.org/factcheck-what-is-the-carbon-footprint-of-streaming-video-on-netflix
 divers . numérique . internet . empreinte horaire:
-  formule: consommation horaire * intensité électricité
+  formule: consommation horaire * commun . intensité électricité
   unité: kgCO2e/heure
 
 divers . numérique . internet . durée journalière:

--- a/data/transport/actions/transport.publicodes
+++ b/data/transport/actions/transport.publicodes
@@ -403,7 +403,7 @@ transport . seuil d'activation 5km:
     > Si quelqu'un nous dit qu'il ne fait que 200km de voiture dans l'année, il y a peu de chances 
     > qu'il s'agisse de trajets de 5km.
 
-  formule: semaines par an * distance moyenne aller-retour trajet court
+  formule: commun . semaines par an * distance moyenne aller-retour trajet court
   unité: km
 
 transport . distance moyenne aller-retour trajet court:
@@ -433,7 +433,7 @@ transport . voiture 5km . distance totale:
       - sinon: distance totale renseignée
 
 transport . voiture 5km . distance totale renseignée:
-  formule: fréquence * distance moyenne aller-retour trajet court * semaines par an
+  formule: fréquence * distance moyenne aller-retour trajet court * commun . semaines par an
 
 transport . voiture 5km . fréquence:
   question: Combien de fois par semaine prenez-vous la voiture pour moins de 5km ?

--- a/data/transport/transport . ferry.publicodes
+++ b/data/transport/transport . ferry.publicodes
@@ -20,7 +20,6 @@ importer!:
         question:
     - transport . ferry . voiture:
         question:
-    - transport . ferry . surface
     - transport . ferry . surface . garage . bas:
         question:
     - transport . ferry . surface . garage . haut:

--- a/data/transport/transport . ferry.publicodes
+++ b/data/transport/transport . ferry.publicodes
@@ -39,7 +39,10 @@ importer!:
 transport . ferry:
   titre: Ferry
   icônes: ⛴
-  formule: heures * vitesse moyenne . métrique * empreinte par km volume
+  formule: |
+    heures
+    * futureco-data . transport . ferry . vitesse moyenne . métrique
+    * futureco-data . transport . ferry . empreinte par km volume
   description: |
     Le modèle ferry provient de [Futur.eco](https://futur.eco/ferry).
     Ce modèle est explicité de manière simplifiée sur la page ["Empreinte par km et passager"](https://nosgestesclimat.fr/documentation/transport/ferry/empreinte-par-km-volume), et basé sur une étude approfondie ([voir la note méthodo complète](https://hackmd.io/@laem/empreinte-ferry))

--- a/data/transport/transport.publicodes
+++ b/data/transport/transport.publicodes
@@ -104,7 +104,7 @@ transport . métro ou tram:
   icônes: 🚊
   description: |
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
-  formule: heures par semaine * impact par heure * semaines par an
+  formule: heures par semaine * impact par heure * commun . semaines par an
 
 transport . métro ou tram . impact par heure:
   formule: impact par km * vitesse
@@ -139,7 +139,7 @@ transport . bus:
   icônes: 🚌
   description: |
     ![](https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Alliance_Auch_ligne_6_Allées_Baylac.JPG/640px-Alliance_Auch_ligne_6_Allées_Baylac.JPG)
-  formule: heures par semaine * impact par heure * semaines par an
+  formule: heures par semaine * impact par heure * commun . semaines par an
 
 transport . bus . impact par heure:
   formule: impact par km * vitesse

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
 		"yaml": "^2.2.2"
 	},
 	"devDependencies": {
-		"@incubateur-ademe/publicodes-tools": "^0.2.1",
+		"@incubateur-ademe/publicodes-commun": "^0.1.1",
+		"@incubateur-ademe/publicodes-tools": "^0.3.0",
 		"@types/glob": "^8.1.0",
 		"cli-progress": "^3.11.2",
 		"deepl-node": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"yaml": "^2.2.2"
 	},
 	"devDependencies": {
-		"@incubateur-ademe/publicodes-commun": "^0.1.1",
+		"@incubateur-ademe/publicodes-commun": "^0.1.2",
 		"@incubateur-ademe/publicodes-tools": "^0.4.2",
 		"@types/glob": "^8.1.0",
 		"cli-progress": "^3.11.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"devDependencies": {
 		"@incubateur-ademe/publicodes-commun": "^0.1.1",
-		"@incubateur-ademe/publicodes-tools": "^0.3.0",
+		"@incubateur-ademe/publicodes-tools": "^0.4.2",
 		"@types/glob": "^8.1.0",
 		"cli-progress": "^3.11.2",
 		"deepl-node": "^1.7.0",

--- a/scripts/i18n/translate-rules.mjs
+++ b/scripts/i18n/translate-rules.mjs
@@ -35,6 +35,9 @@ import {
 import { fetchTranslation, fetchTranslationMarkdown } from './deepl.js'
 import gitDiff from 'git-diff'
 import { getModelFromSource } from '@incubateur-ademe/publicodes-tools/compilation'
+import createPrompt from 'prompt-sync'
+
+const prompt = createPrompt()
 
 const { srcLang, destLangs, srcFile, onlyUpdateLocks, interactiveMode } =
 	getArgs(
@@ -49,6 +52,16 @@ const { srcLang, destLangs, srcFile, onlyUpdateLocks, interactiveMode } =
 			interactiveMode: true,
 		}
 	)
+
+const cmds = [
+	{ info: 'translate', cmd: 't' },
+	{ info: 'update .lock attribute', cmd: 'u' },
+	{ info: 'skip', cmd: 's' },
+	{ info: 'print current translation', cmd: 'p' },
+	{ info: 'abort', cmd: 'a' },
+]
+
+const abrvs = cmds.map(({ cmd }) => cmd)
 
 const translateTo = async (
 	srcLang,
@@ -130,16 +143,24 @@ const translateTo = async (
 					}
 				)
 				console.log(
-					`\n${styledRuleNameWithOptionalAttr(rule, attr)}${
-						isNewRule ? ` ${italic(green('new'))}` : ''
-					}\n${diff}`
+					`\n${dim('---')} ${italic(
+						green(isNewRule ? 'NEW RULE' : 'MODIFIED RULE')
+					)} ${dim('---------------------------')}`
+				)
+				console.log(`\n${styledRuleNameWithOptionalAttr(rule, attr)}\n${diff}`)
+				console.log(
+					`${dim(
+						`----${
+							isNewRule ? '---------' : '--------------'
+						}---------------------------`
+					)}`
 				)
 				do {
 					if (answer === 'p') {
 						console.log(`${dim('')}${translatedRules[rule][attr]}`)
 					}
-					answer = ask(dim(`(tuspa): `), ['u', 's', 't', 'a'])
-				} while (!['u', 's', 't', 'a'].includes(answer))
+					answer = prompt(dim(`(${abrvs.join()}): `))
+				} while (!abrvs.includes(answer))
 			}
 			if (answer === 'a') {
 				console.log('Exiting...')
@@ -212,14 +233,7 @@ destLangs.forEach(async (destLang) => {
 		if (interactiveMode) {
 			console.log(
 				`For each rule, you can choose to:\n\n${styledPromptActions(
-					[
-						'translate',
-						'update .lock attribute',
-						'skip',
-						'print current translation',
-						'abort',
-						// TODO: add a 'suggest translation' option?
-					],
+					cmds.map(({ info }) => info),
 					'\n'
 				)}`
 			)

--- a/scripts/modelOptim.mjs
+++ b/scripts/modelOptim.mjs
@@ -72,7 +72,7 @@ export function constantFoldingFromJSONFile(
 		const foldedRules = getRawNodes(constantFolding(engine, toKeep))
 
 		log(`Writing in '${jsonDestPath}'...`)
-		writeFileSync(jsonDestPath, JSON.stringify(foldedRules))
+		writeFileSync(jsonDestPath, JSON.stringify(foldedRules, null, 2))
 		return { nbRules: Object.keys(foldedRules).length }
 	} catch (error) {
 		return { err }

--- a/scripts/modelOptim.mjs
+++ b/scripts/modelOptim.mjs
@@ -32,10 +32,9 @@ const rulesToKeep = [
 
 export function compressRules(jsonPathWithoutExtension) {
 	const destPath = `${jsonPathWithoutExtension}-opti.json`
-	const err = constantFoldingFromJSONFile(
+	let res = constantFoldingFromJSONFile(
 		jsonPathWithoutExtension + '.json',
 		destPath,
-		['**/translated-*.yaml'],
 		([ruleName, ruleNode]) => {
 			return (
 				rulesToKeep.includes(ruleName) ||
@@ -44,48 +43,38 @@ export function compressRules(jsonPathWithoutExtension) {
 			)
 		}
 	)
-	return err
+	return res
 }
 
 /**
  * Applies a constant folding optimization pass to the parsed rules from the [model] path.
  *
- * @param model Path to the folder containing the Publicodes files or to a JSON file (the extension must be '.json' then).
+ * @param modelPath Path to the folder containing the Publicodes files or to a JSON file (the extension must be '.json' then).
  * @param json Path to the JSON file target.
- * @param ignore Regexp matching files to ignore from the model tree.
  * @param toKeep Predicate function to determine which rule should be kept.
- * @param verbose Whether to log the optimization pass.
+ * @param verbose If true, the function will log the steps of the optimization pass.
  *
  * @returns An error message if the optimization pass failed, undefined otherwise.
  */
 export function constantFoldingFromJSONFile(
-	model,
+	modelPath,
 	jsonDestPath,
-	ignore,
 	toKeep,
 	verbose = false
 ) {
 	const log = verbose ? console.log : function (_) {}
 	try {
-		var rules
-
-		if (path.extname(model) === '.json') {
-			log('Parsing rules from the JSON file:', model)
-			rules = JSON.parse(readFileSync(model, 'utf8'))
-		} else {
-			const modelPath = path.join(path.resolve(model), '**/*.publicodes')
-			log(`Parsing rules from ${modelPath}...`)
-			rules = readRawRules(modelPath, ignore ?? [])
-		}
-
+		log('Parsing rules from the JSON file:', modelPath)
+		const rules = JSON.parse(readFileSync(modelPath, 'utf8'))
 		const engine = new Engine(rules, { logger: disabledLogger })
 
 		log('Constant folding pass...')
-		const foldedRules = constantFolding(engine, toKeep)
+		const foldedRules = getRawNodes(constantFolding(engine, toKeep))
 
 		log(`Writing in '${jsonDestPath}'...`)
-		writeFileSync(jsonDestPath, JSON.stringify(getRawNodes(foldedRules)))
+		writeFileSync(jsonDestPath, JSON.stringify(foldedRules))
+		return { nbRules: Object.keys(foldedRules).length }
 	} catch (error) {
-		return error
+		return { err }
 	}
 }

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -114,9 +114,9 @@ try {
 	})
 	if (!markdown) {
 		console.log(
-			`✅ ${
+			`✅ ${cli.yellow(
 				Object.keys(baseRules).length
-			} base rules have been correctly parsed`
+			)} base rules have been correctly parsed`
 		)
 	}
 } catch (err) {

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -29,7 +29,7 @@ const { srcLang, srcFile, destLangs, destRegions, markdown } = cli.getArgs(
 		target: true,
 		model: { supportedRegionCodes },
 		file: true,
-		defaultSrcFile: 'data/**/*.publicodes',
+		defaultSrcFile: 'data',
 		markdown: true,
 	}
 )

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -112,9 +112,13 @@ try {
 		//    https://github.com/datagir/nosgestesclimat/issues/1722
 		logger: { log: (_) => {}, warn: (_) => {}, err: (_) => {} },
 	})
-	console.log(
-		`✅ ${Object.keys(baseRules).length} base rules have been correctly parsed`
-	)
+	if (!markdown) {
+		console.log(
+			`✅ ${
+				Object.keys(baseRules).length
+			} base rules have been correctly parsed`
+		)
+	}
 } catch (err) {
 	console.error(`❌ An error occured while trying to parse the base rules:\n`)
 	logPublicodesError(err)

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -42,7 +42,7 @@ function writeSupportedRegions() {
 		console.log(
 			markdown
 				? `| Supported regions | :heavy_check_mark: | Ø |`
-				: ` ✅ The supported regions have been correctly written in: ${supportedRegionPath}`
+				: `✅ The supported regions have been correctly written in: ${supportedRegionPath}`
 		)
 	} catch (err) {
 		if (markdown) {
@@ -51,7 +51,7 @@ function writeSupportedRegions() {
 			)
 		} else {
 			console.log(
-				' ❌ An error occured while writting rules in:',
+				'❌ An error occured while writting rules in:',
 				supportedRegionPath
 			)
 			console.log(err.message)
@@ -97,7 +97,7 @@ try {
 		verbose: !markdown,
 	})
 } catch (err) {
-	console.error(` ❌ An error occured while trying to parse the base rules:\n`)
+	console.error(`❌ An error occured while trying to parse the base rules:\n`)
 	console.error(err.message)
 	exit(-1)
 }
@@ -112,8 +112,11 @@ try {
 		//    https://github.com/datagir/nosgestesclimat/issues/1722
 		logger: { log: (_) => {}, warn: (_) => {}, err: (_) => {} },
 	})
+	console.log(
+		`✅ ${Object.keys(baseRules).length} base rules have been correctly parsed`
+	)
 } catch (err) {
-	console.error(` ❌ An error occured while trying to parse the base rules:\n`)
+	console.error(`❌ An error occured while trying to parse the base rules:\n`)
 	logPublicodesError(err)
 	exit(-1)
 }

--- a/scripts/rulesToJSON.worker.mjs
+++ b/scripts/rulesToJSON.worker.mjs
@@ -8,9 +8,9 @@ import { compressRules } from './modelOptim.mjs'
 
 function writeRules(rules, path, destLang, regionCode, markdown) {
 	try {
-		fs.writeFileSync(path, JSON.stringify(rules))
+		fs.writeFileSync(path, JSON.stringify(rules, null, 2))
 		if (!markdown) {
-			console.log(` ✅ ${regionCode}-${destLang} written`)
+			console.log(`✅ ${regionCode}-${destLang} written`)
 		}
 	} catch (err) {
 		return err
@@ -55,14 +55,14 @@ export default ({
 	)
 	if (werr) {
 		return {
-			err: ` ❌ Compilation ${regionCode}-${destLang}: ${werr}`,
+			err: `❌ Compilation ${regionCode}-${destLang}: ${werr}`,
 		}
 	}
 	const oerr = compressRules(destPathWithoutExtension)
 	if (oerr) {
-		return { err: ` ❌ Optimization ${regionCode}-${destLang}: ${oerr}` }
+		return { err: `❌ Optimization ${regionCode}-${destLang}: ${oerr}` }
 	} else if (!markdown && !oerr) {
-		console.log(` ✅ ${regionCode}-${destLang} optimized`)
+		console.log(`✅ ${regionCode}-${destLang} optimized`)
 	}
 	return { ok: `<li>${regionCode}-${destLang}</li>` }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     publicodes "^1.0.0-beta.71"
 
-"@incubateur-ademe/publicodes-tools@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.3.0.tgz#d1b6519b4dd49ca37772f7f294a2eb4d40c99b7e"
-  integrity sha512-w83ZmwzeWWKqKswoptAtubFneOueOJE21mu3clMDLkB+PutPLLcgedc0FXXO0sY1k/KxSB55i06val99fzm90w==
+"@incubateur-ademe/publicodes-tools@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.4.2.tgz#e614855d95d7c1f1ef0cdc8de8162c11a8ca6c10"
+  integrity sha512-i/SYYxO1I/enMTIA0tLSm4FM0P2AXcfW5rI7xfkBf1jnTePXlJpe7g3baxI8wEQQRosqr040Sj7Sb79S8kWWfg==
   dependencies:
     "@types/node" "^18.11.18"
     publicodes "^1.0.0-beta.71"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@incubateur-ademe/publicodes-commun@^0.1.1":
+"@incubateur-ademe/publicodes-commun@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-commun/-/publicodes-commun-0.1.2.tgz#a3168568dd7ac4090ec7f0af7ff06cdde4a28f49"
   integrity sha512-1Kq606UIg4zxmduJuO3lQt0BSH9/klHJEz8c2DBuaVJzT78QQ4rW5T7I2NZ9wiXgVEF+4n0u0005xn9sm1u6+w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,17 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@incubateur-ademe/publicodes-tools@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.2.1.tgz#94585b3f07c6c054e6ffd7ef44081a4624b8a851"
-  integrity sha512-DFma9Jkwug7LQIGK1r8vjsmGZAc4m2EO8zbGF4DgCvFLe6fPz9ZpYAnLE9pisyS87AigxDgfRVm5UerFU9Be6g==
+"@incubateur-ademe/publicodes-commun@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-commun/-/publicodes-commun-0.1.1.tgz#b708017d91946100703a64ccfbb34343b68f5c3d"
+  integrity sha512-KgRWZWT0Q/ndnHL/og70sFMn7j2tauE6HxBz5NXOXa9O45B/oP0nUTJwYMLPGQ+ScPrvvz56DzXrD0rg9JFBxw==
+  dependencies:
+    publicodes "^1.0.0-beta.71"
+
+"@incubateur-ademe/publicodes-tools@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@incubateur-ademe/publicodes-tools/-/publicodes-tools-0.3.0.tgz#d1b6519b4dd49ca37772f7f294a2eb4d40c99b7e"
+  integrity sha512-w83ZmwzeWWKqKswoptAtubFneOueOJE21mu3clMDLkB+PutPLLcgedc0FXXO0sY1k/KxSB55i06val99fzm90w==
   dependencies:
     "@types/node" "^18.11.18"
     publicodes "^1.0.0-beta.71"


### PR DESCRIPTION
Use the new [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun/tree/main) package.

## Notes

As we now import the rule `intensité électricité` in the namespace `commun`, I needed to change the rule name in all i18n models. It feels a little bit weird :thinking: 

## Changelog

- Replace the `commun.publicodes` file with the `@incubateur-ademe/publicodes-commun` package
- Use the default namespace `futureco-data` for the ferry
- Upgrade to `@incubateur-ademe/publicodes-tools@v0.4.2`