### PR TITLE
🐛 Fix: bug persona Marie sur la page Profil

### DIFF
--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -25573,3 +25573,10 @@ alimentation . une semaine chocolat chaud végétalien:
   titre: a week of vegan hot chocolate
   titre.auto: a week of vegan hot chocolate
   titre.lock: une semaine chocolat chaud végétalien
+transport . ferry . surface:
+  titre: surface
+  titre.auto: surface
+  titre.lock: surface
+  description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
+  description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">futureco-data</a> model.'
+  description.lock: '> ℹ️ Cette règle provient du modèle [futureco-data](https://github.com/laem/futureco-data).'

--- a/data/transport/transport . ferry.publicodes
+++ b/data/transport/transport . ferry.publicodes
@@ -20,6 +20,7 @@ importer!:
         question:
     - transport . ferry . voiture:
         question:
+    - transport . ferry . surface
     - transport . ferry . surface . garage . bas:
         question:
     - transport . ferry . surface . garage . haut:


### PR DESCRIPTION
Assez mystérieusement, on a un souci avec le persona Marie actuellement : si on sélectionne le persona moyen (situation vide), en allant sur la page "Profil", l'app casse avec cette erreur :

<img width="847" alt="image" src="https://github.com/incubateur-ademe/nosgestesclimat/assets/55186402/e7c079af-0442-4aef-95ec-25545dc3d18a">

Il ne me semble pas que ce soit un pb d'optim dans la mesure ou je teste avec l'optim désactivée..

En important la règle manquante depuis futureco, j'ai l'impression que le problème est résolu .. C'est peut etre lié au fait qu'on importe les enfants de `ferry . surface` sans importer leurs parents mais je trouve que la manière dont arrive ce bug est étrange