### PR TITLE
[clean] plus `références` dans le modèle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Ici réside le modèle de calcul de https://nosgestesclimat.fr.
 
 ### Écriture des modèles du simulateur
 
-Le modèle d'empreinte climat personnelle est écrit dans un français le plus lisible possible : 
+Le modèle d'empreinte climat personnelle est écrit dans un français le plus lisible possible :
 
 ```yaml
-# Premier extrait 
+# Premier extrait
 douche . litres par minute:
   unité: l/minute
   formule:
@@ -16,7 +16,7 @@ douche . litres par minute:
         alors: 9
       - sinon: 18
 
-# Deuxième extrait 
+# Deuxième extrait
 transport . avion . coefficient de forçage radiatif:
   description: >
     Le forçage radiatif, c'est la capacité d'une émission de gaz à rechauffer la
@@ -24,11 +24,11 @@ transport . avion . coefficient de forçage radiatif:
     Un vol émet du CO₂, mais aussi d'autres gaz, ainsi que de la vapeur libérée en haute altitude. Le forçage radiatif de ces émissions est conséquent et doit donc être pris en compte, mais c'est une estimation très compliquée.
     L'effet de la vapeur d'eau est temporaire : elle disparaît à court-terme par rapport au CO₂ qui reste très longtemps présent. Son effet n'en reste pas moins massif.
   formule: 2
-  références:
+  note: |
+    Plus d'informations ici:
     - https://www.carbonindependent.org/sources_aviation.html
     - http://www.bilans-ges.ademe.fr/forum/viewtopic.php?f=20&t=4009&sid=dea7e08c81c2f723b803d27e7e2a8797
     - https://fr.wikipedia.org/wiki/Impact_climatique_du_transport_a%C3%A9rien#Pond%C3%A9ration_des_%C3%A9missions
-
 ```
 
 :pen: Suivez [le guide pour contribuer](https://github.com/datagir/nosgestesclimat/blob/master/CONTRIBUTING.md).

--- a/data/actions/alimentation.publicodes
+++ b/data/actions/alimentation.publicodes
@@ -228,9 +228,9 @@ alimentation . gaspillage alimentaire:
   inactive: oui
   icônes: 🍲🚯
   titre: Réduire mon gaspillage alimentaire
-  note: Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
-  références:
-    - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
+  note: |
+    Voir le rapport sur [l'estimation des impacts du gaspillage alimentaire des ménages](https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages), 
+    page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
 
 alimentation . déchets . action:
   titre: Passer au zéro déchet

--- a/data/actions/archives/humour.archive
+++ b/data/actions/archives/humour.archive
@@ -50,6 +50,5 @@ humour . lecture AR5 . empreinte usage . ordinateur . conso:
 humour . lecture AR5 . empreinte usage . ordinateur . puissance:
   formule: 0.015
   unité: kW
-  références: 
-    - https://www.quora.com/How-much-energy-does-a-regular-laptop-consume
+  note: Voir https://www.quora.com/How-much-energy-does-a-regular-laptop-consume
 

--- a/data/actions/divers.publicodes
+++ b/data/actions/divers.publicodes
@@ -52,7 +52,7 @@ divers . publicité:
     <details><summary>Sur iPhone</summary>L'écosystème iOS [est cadenassé par Apple](https://support.mozilla.org/fr/kb/modules-complementaires-pour-firefox-sous-ios), donc il n'est pas possible de faire grand chose.</details>
     <details><summary>Sur Android</summary>Vous pouvez utiliser Firefox et y installer l'extension muBlock, ou un autre navigateur du magasin d'application permettant le blocage (ce n'est pas le cas de Chrome). Pour les applications, c'est plus compliqué, mais il est possible d'installer des alternatives d'applications sans publicité (par exemple [Youtube Vanced](https://vancedapp.com) ou [New Pipe](https://newpipe.net) en remplacement de l'application Youtube) ou d'installer un bloqueur pour toutes les applications (par exemple [Blokada](https://blokada.org/)).</details>
 
-  références:
+  note: |
     ADEME: https://librairie.ademe.fr/dechets-economie-circulaire/325-biens-d-equipement-benefices-environnementaux-d-allonger-leur-duree-de-vie.html
   inactive: oui
 

--- a/data/actions/logement.publicodes
+++ b/data/actions/logement.publicodes
@@ -174,16 +174,16 @@ logement . éclairage . consommation de l'éclairage:
   titre: Éclairage dans la facture d'électricité
   formule: électricité * 5.6%
   description: La part dans l'électricité consommée consacrée à l'éclairage.
-  références:
-    Réduire sa facture d’électricité, Juin 2019, ADEME: https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-reduire-facture-electricite.pdf#page=2
+  note: |
+    Chiffre issu du guide [Réduire sa facture d’électricité, Juin 2019, ADEME](https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf)
 
 logement . éclairage . avec LED:
   formule: consommation de l'éclairage / 6.43
   description: Consommation d'électricité dans un scénario avec ampoules LED.
   note: |
     6.43, c'est le rapport entre la conso annuelle de 10 ampoules 60W (450kWh) vs 10 LED équivalent 60 W (70kWh).
-  références:
-    Réduire sa facture d’électricité, Juin 2019, ADEME: https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-reduire-facture-electricite.pdf#page=7
+
+    Chiffre issu du guide [Réduire sa facture d’électricité, Juin 2019, ADEME](https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf)
 
 logement . remplacer gaz par PAC:
   titre: Passer de chaudière gaz à pompe à chaleur
@@ -211,8 +211,8 @@ logement . remplacer gaz par PAC:
     Nous considérons pour l'instant que le remplacement des kWh de gaz par la même quantité de kWh électrique est une bonne approximation de premier ordre. Nous pourrons par la suite l'adapter en fonction du rendement des installations résidentielles.
 
     Cette action chiffre le remplacement de la chaudière gaz, si vous chauffez aussi votre eau au gaz il faudra choisir une PAC qui peut aussi chauffer l'eau.
-  références:
-    Guide ADEME PAC: https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-installer-une-pompe-a-chaleur.pdf
+
+    Voir [Guide ADEME PAC](https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-installer-une-pompe-a-chaleur.pdf)
 
 logement . pompe à chaleur:
   formule: (chauffage . gaz . consommation / coefficient COP) * électricité . intensité carbone
@@ -221,10 +221,10 @@ logement . pompe à chaleur . coefficient COP:
   titre: Coefficient de performance réel
   formule: 2
   description: Pour 1kWh d'électricité consommée, combien de kWh de chaleur fournis ?
-  note: Nous choississons un coefficient conservateur (l'ADEME conseille un COP > 3).
-  références:
-    Guide EDF: https://particulier.edf.fr/fr/accueil/guide-energie/electricite/pompe-a-chaleur.html
-    Pompe à chaleur ou radiateurs électriques ?: https://conseils-thermiques.org/contenu/pompe-a-chaleur-ou-radiateur-electrique.php
+  note: |
+    Nous choississons un coefficient conservateur (l'ADEME conseille un COP > 3).
+    Voir le [Guide EDF](https://particulier.edf.fr/fr/accueil/guide-energie/electricite/pompe-a-chaleur.html).
+    Plus d'informations également sur l'article [Pompe à chaleur ou radiateurs électriques ?](https://conseils-thermiques.org/contenu/pompe-a-chaleur-ou-radiateur-electrique.php)
 
 logement . chaudière remplacement:
   titre: Passer à une chaudière bois ou à une pompe à chaleur
@@ -266,9 +266,7 @@ logement . gain rénovation:
   formule: 39%
   note: |
     Gain énergétique moyen après rénovation sur un programme de l'ANAH de 13 000 logements ciblant les "passoires thermiques".
-
-  références:
-    Programme "habiter mieux" de l'ANAH: https://www.anah.fr/actualites/detail/actualite/lanah-publie-un-premier-bilan-du-programme-habiter-mieux/?tx_news_pi1[controller]=News&tx_news_pi1[action]=detail&cHash=26d00161febd159fcbca45d2032a56b3
+    Plus d'informations dans le programme [MaPrimeRénov’ Sérénité](https://france-renov.gouv.fr/aides/mpr/serenite) (ex Habiter Mieux de L’Anah).
 
 logement . propriétaire:
   question: Etes-vous propriétaire de votre logement ?

--- a/data/actions/transport.publicodes
+++ b/data/actions/transport.publicodes
@@ -115,9 +115,8 @@ transport . éco-conduite:
 
     L’application de l’éco-conduite est d’autant plus pertinente en ville et en zone urbaine ou les arrêts et 
     le redémarrage sont fréquents.
-
-  références:
-    Guide de formation à l'éco-conduite ADEME-LaPoste: https://www.ademe.fr/sites/default/files/assets/documents/66885_guide_ecoconduite.pdf#page=8
+  note: |
+    Voir le [Guide de formation à l'éco-conduite ADEME-LaPoste](https://expertises.ademe.fr/air-mobilites/mobilite-transports/passer-a-laction/solutions-technologiques/dossier/optimiser-lutilisation-lentretien-vehicule/lecoconduite-attitude-a-adopter)
 
 transport . éco-conduite . recalcul:
   note: Un recalcul est nécessaire ici, car l'utilisateur peut avoir utilisé l'outil d'aide à la saisie qui proratise alors la variable km au nombre de voyageurs. Sinon ce n'est pas le cas.
@@ -149,9 +148,8 @@ transport . covoiturage:
     Si le covoiturage longue distance est bien connu en France, celui des courtes distances est presque inexistant : aujourd’hui seuls 3 % des déplacements domicile-travail sont réalisés en covoiturage.
 
     Dans tous les cas, pensez à adapter votre mode de transport à la distance et à privilégier les modes doux ou transports en commun (bus, métro, vélo, marche, etc.) le plus possible. Le calculateur [Mon Impact Transport](https://monimpacttransport.fr/) vous permet de visualiser et comparer l'impact des différents modes de déplacement.
-
-  références:
-    - https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122
+  note: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122)
 
 transport . boulot:
   icônes: 🏢
@@ -170,19 +168,17 @@ transport . boulot . covoiturage:
     Sachez que depuis 2020, vous pouvez demander à votre employeur le [forfait mobilité durable](https://www.service-public.fr/particuliers/actualites/A14046), pour que votre covoiturage soit rémunéré jusqu'à 400€/an, exonérés d'impôt et de cotisations sociales !
 
     Dans tous les cas, pensez à adapter votre mode de transport à la distance et à privilégier les modes doux ou transports en commun (bus, métro, vélo, marche, etc.) le plus possible. Le calculateur [Mon Impact Transport](https://monimpacttransport.fr/) vous permet de visualiser et comparer l'impact des différents modes de déplacement.
-
-  références:
-    - https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122
+  note: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122)
 
 transport . réduction covoiturage:
   formule: 20%
   description: |
-    On pourrait naïvement penser que le covoiturage divise par 2 l'empreinte par personne. Mais en réalité, une étude menée en Île-de-France montre que les réductions sont plutôt de l'ordre de 20%... avant les effets rebonds, qui réduisent le gain final du covoiturage à seulement 6%.
+    On pourrait naïvement penser que le covoiturage divise par 2 l'empreinte par personne. Mais en réalité, [une étude menée en Île-de-France](https://www.sciencedirect.com/science/article/pii/S1361920918303201) montre que les réductions sont plutôt de l'ordre de 20%... avant les effets rebonds, qui réduisent le gain final du covoiturage à seulement 6%.
 
     ![](https://images.theconversation.com/files/297327/original/file-20191016-98644-c9y1zz.png?ixlib=rb-1.1.0&q=30&auto=format&w=754&h=588&fit=crop&dpr=2)
-  références:
-    - https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122
-    - https://www.sciencedirect.com/science/article/pii/S1361920918303201
+  note: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122).
 
 transport . boulot . distance:
   formule: semaines * hebdomadaire
@@ -608,5 +604,5 @@ transport . km autoroute:
     Paris ⇄ Marseille: 1600
     Bordeaux ⇄ Lyon: 1100
   par défaut: 1200
-  références:
-    - https://twitter.com/Tomsawy22670318/status/1274257124701462528
+  note: |
+    Fil twitter intéressant sur le sujet: https://twitter.com/Tomsawy22670318/status/1274257124701462528.

--- a/data/alimentation/boisson.publicodes
+++ b/data/alimentation/boisson.publicodes
@@ -91,7 +91,7 @@ alimentation . boisson . tasse de café:
 alimentation . boisson . tasse de café . empreinte café moulu:
   formule: 10.09
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, café moulu](https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu).
+  note: Facteur d'émission issu d'[Agibalyse, café moulu](https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu).
 
 alimentation . boisson . tasse de café . quantité café par tasse:
   formule: 0.012
@@ -116,7 +116,7 @@ alimentation . boisson . tasse de thé . empreinte thé infusé sans consommatio
 alimentation . boisson . tasse de thé . empreinte thé infusé:
   formule: 0.04
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9).
+  note: Facteur d'émission issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9).
 
 alimentation . boisson . tasse de thé . part consommation empreinte thé infusé:
   formule: 25%
@@ -140,7 +140,7 @@ alimentation . boisson . tasse de chocolat chaud:
 alimentation . boisson . tasse de chocolat chaud . empreinte cacao en poudre:
   formule: 27.06
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, cacao non sucré soluble](https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble).
+  note: Facteur d'émission issu d'[Agibalyse, cacao non sucré soluble](https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble).
 
 alimentation . boisson . tasse de chocolat chaud . quantité cacao par tasse:
   formule: 0.020
@@ -183,18 +183,18 @@ alimentation . type de lait . lait d'avoine:
 alimentation . empreinte lait de vache:
   formule: 1.32
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, lait demi-écrémé pasteurisé](https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9).
+  note: Facteur d'émission issu d'[Agibalyse, lait demi-écrémé pasteurisé](https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9).
 
 alimentation . empreinte lait de soja:
   formule: 0.44
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, boisson au soja nature](https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature).
+  note: Facteur d'émission issu d'[Agibalyse, boisson au soja nature](https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature).
 
 alimentation . empreinte lait d'avoine:
   titre: lait d'avoine
   formule: 0.54
   unité: kgCO2e/kg
-  note: FE issu d'[Agibalyse, boisson à base d'avoine nature](https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature).
+  note: Facteur d'émission issu d'[Agibalyse, boisson à base d'avoine nature](https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature).
 
 alimentation . boisson . tasse de chocolat chaud . quantité lait par tasse:
   formule: 0.200
@@ -221,7 +221,7 @@ alimentation . boisson . eau en bouteille . consommation annuelle:
 alimentation . boisson . eau en bouteille . empreinte:
   formule: 0.27
   unité: kgCO2e/l
-  note: FE issu d'[Agibalyse, eau embouteillée de source](https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source).
+  note: Facteur d'émission issu d'[Agibalyse, eau embouteillée de source](https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source).
 
 alimentation . boisson . eau en bouteille . affirmatif:
   titre: Eau en bouteille
@@ -255,17 +255,17 @@ alimentation . boisson . sucrées . facteur:
 alimentation . boisson . sucrées . facteur sodas:
   formule: 0.51
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, Cola, sucré](https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, Cola, sucré](https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . facteur jus de fruits:
   formule: 0.91
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, Jus multifruit, pur jus, standard](https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, Jus multifruit, pur jus, standard](https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . facteur sirops:
   formule: 0.10
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, boisson préparée à partir de sirop](https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau), 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, boisson préparée à partir de sirop](https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau), 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . litres:
   titre: Consommation de boissons sucrées
@@ -300,17 +300,17 @@ alimentation . boisson . alcool . facteur:
 alimentation . boisson . alcool . facteur bière:
   formule: 1.12
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, bière coeur de marché](https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool)), 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, bière coeur de marché](https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool)), 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
 
 alimentation . boisson . alcool . facteur vin:
   formule: 1.22
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, vin blanc sec](https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec), 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, vin blanc sec](https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec), 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
 
 alimentation . boisson . alcool . facteur coktail:
   formule: 0.91
   unité: kgCO2e/l
-  note: FE issu d'[Agribalyse, coktail base rhum](https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
+  note: Facteur d'émission issu d'[Agribalyse, coktail base rhum](https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
 
 alimentation . boisson . alcool . litres:
   titre: Consommation d'alcool

--- a/data/alimentation/boisson.publicodes
+++ b/data/alimentation/boisson.publicodes
@@ -91,8 +91,7 @@ alimentation . boisson . tasse de café:
 alimentation . boisson . tasse de café . empreinte café moulu:
   formule: 10.09
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu
+  note: FE issu d'[Agibalyse, café moulu](https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu).
 
 alimentation . boisson . tasse de café . quantité café par tasse:
   formule: 0.012
@@ -117,13 +116,13 @@ alimentation . boisson . tasse de thé . empreinte thé infusé sans consommatio
 alimentation . boisson . tasse de thé . empreinte thé infusé:
   formule: 0.04
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9
+  note: FE issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9).
 
 alimentation . boisson . tasse de thé . part consommation empreinte thé infusé:
   formule: 25%
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9
+  note: |
+    Selon la décomposition issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9),
+    la part de consommation dans le facteur d'émission du thé représente 25%.
 
 alimentation . boisson . tasse de thé . quantité thé par tasse:
   formule: 0.250
@@ -141,8 +140,7 @@ alimentation . boisson . tasse de chocolat chaud:
 alimentation . boisson . tasse de chocolat chaud . empreinte cacao en poudre:
   formule: 27.06
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble
+  note: FE issu d'[Agibalyse, cacao non sucré soluble](https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble).
 
 alimentation . boisson . tasse de chocolat chaud . quantité cacao par tasse:
   formule: 0.020
@@ -185,21 +183,18 @@ alimentation . type de lait . lait d'avoine:
 alimentation . empreinte lait de vache:
   formule: 1.32
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9
+  note: FE issu d'[Agibalyse, lait demi-écrémé pasteurisé](https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9).
 
 alimentation . empreinte lait de soja:
   formule: 0.44
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature
+  note: FE issu d'[Agibalyse, boisson au soja nature](https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature).
 
 alimentation . empreinte lait d'avoine:
   titre: lait d'avoine
   formule: 0.54
   unité: kgCO2e/kg
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature
+  note: FE issu d'[Agibalyse, boisson à base d'avoine nature](https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature).
 
 alimentation . boisson . tasse de chocolat chaud . quantité lait par tasse:
   formule: 0.200
@@ -226,8 +221,7 @@ alimentation . boisson . eau en bouteille . consommation annuelle:
 alimentation . boisson . eau en bouteille . empreinte:
   formule: 0.27
   unité: kgCO2e/l
-  références:
-    - https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source
+  note: FE issu d'[Agibalyse, eau embouteillée de source](https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source).
 
 alimentation . boisson . eau en bouteille . affirmatif:
   titre: Eau en bouteille
@@ -261,23 +255,17 @@ alimentation . boisson . sucrées . facteur:
 alimentation . boisson . sucrées . facteur sodas:
   formule: 0.51
   unité: kgCO2e/l
-  note: FE issu d'agribalyse (Cola, sucré), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants
+  note: FE issu d'[Agribalyse, Cola, sucré](https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . facteur jus de fruits:
   formule: 0.91
   unité: kgCO2e/l
-  note: FE issu d'agribalyse (Jus multifruit, pur jus, standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard
+  note: FE issu d'[Agribalyse, Jus multifruit, pur jus, standard](https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . facteur sirops:
   formule: 0.10
   unité: kgCO2e/l
-  note: FE issu d'agribalyse, 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau
+  note: FE issu d'[Agribalyse, boisson préparée à partir de sirop](https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau), 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
 
 alimentation . boisson . sucrées . litres:
   titre: Consommation de boissons sucrées
@@ -312,23 +300,17 @@ alimentation . boisson . alcool . facteur:
 alimentation . boisson . alcool . facteur bière:
   formule: 1.12
   unité: kgCO2e/l
-  note: FE issu d'agribalyse, 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool)
+  note: FE issu d'[Agribalyse, bière coeur de marché](https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool)), 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
 
 alimentation . boisson . alcool . facteur vin:
   formule: 1.22
   unité: kgCO2e/l
-  note: FE issu d'agribalyse, 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec
+  note: FE issu d'[Agribalyse, vin blanc sec](https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec), 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
 
 alimentation . boisson . alcool . facteur coktail:
   formule: 0.91
   unité: kgCO2e/l
-  note: FE issu d'agribalyse (coktail type punch), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
-  reference:
-    - https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum
+  note: FE issu d'[Agribalyse, coktail base rhum](https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
 
 alimentation . boisson . alcool . litres:
   titre: Consommation d'alcool

--- a/data/alimentation/déchets.publicodes
+++ b/data/alimentation/déchets.publicodes
@@ -69,7 +69,7 @@ alimentation . déchets . niveau zéro déchets:
     On considère que la part de gens vivant réellement sans générer aucun déchets est peu représentative même au sein du mouvement zéro déchets. Ainsi,
     on considère qu'un mode de vie zéro déchets correspond à une division par 4 de toutes les autres quantitées de déchets (OMR, CS et déchetterie).
     Seuls les déchets putrescibles sont exclus des réduction opérées car ils ne concernent pas les emballages.
-  référence: https://librairie.ademe.fr/dechets-economie-circulaire/1906-bien-vivre-en-zero-dechet.html
+    Voir l'analyse [Bien vivre en zéro déchet de l'ADEME](https://librairie.ademe.fr/dechets-economie-circulaire/1906-bien-vivre-en-zero-dechet.html).
 
 alimentation . déchets . niveau moyen:
   formule:
@@ -170,8 +170,7 @@ alimentation . déchets . gestes . gaspillage alimentaire:
 alimentation . déchets . gestes . empreinte gaspillage alimentaire:
   formule: 30
   unité: kgCO2e
-  références:
-    - Tableau page 111 de [l'étude ADEME](https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html)
+  note: Voir tableau page 111 de [l'étude ADEME](https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html)
 
 alimentation . déchets . gestes . stop pub . présent:
   question: Avez-vous un stop pub sur votre boîte aux lettres ?
@@ -248,9 +247,9 @@ alimentation . déchets . gestes . bonus acheter en vrac . gisement réduction:
 alimentation . déchets . gestes . bonus acheter en vrac . empreinte plastique:
   formule: 2.383
   unité: kgCO2e/kg
-  référence: Base Carbone - Plastique - moyenne - neuf
+  note: FE issu de la Base Carbone (Plastique - moyenne - neuf)
 
 alimentation . déchets . gestes . bonus acheter en vrac . empreinte carton:
   formule: 0.390
   unité: kgCO2e/kg
-  référence: Base Carbone - Carton - neuf
+  note: FE issu de la Base Carbone (Carton - neuf)

--- a/data/alimentation/déchets.publicodes
+++ b/data/alimentation/déchets.publicodes
@@ -148,7 +148,7 @@ alimentation . déchets . omr . putrescibles . impact compost domestique:
   formule: 0.009
   unité: kgCO2e/kg
   note: |
-    Le FE considéré est : Déchets de cuisine et déchets verts - Compostage domestique en bac - Impacts
+    Le facteur d'émission considéré est : Déchets de cuisine et déchets verts - Compostage domestique en bac - Impacts
 
 alimentation . déchets . gestes . gaspillage alimentaire . présent:
   question: Cherchez-vous à réduire votre gaspillage alimentaire (que les produits aient été cuisinés ou non) ?
@@ -163,7 +163,7 @@ alimentation . déchets . gestes . gaspillage alimentaire:
   formule: (-1) * empreinte gaspillage alimentaire
   unité: kgCO2e
   note: |
-    Il faut savoir qu'il existe un double comptage avec la fin de vie des pertes non-comestibles chez le consommateur déjà prise en compte dans les FE repas
+    Il faut savoir qu'il existe un double comptage avec la fin de vie des pertes non-comestibles chez le consommateur déjà prise en compte dans les facteurs d'émission repas
     de la Base Carbone. Cependant, ce double comptage est peu significatif.
     Pour aller plus loin dans cette discussion, notamment les questions de périmètre et de comparaison avec l'étude internationale de la FAO, voir nos commentaires [ici](https://github.com/datagir/nosgestesclimat/pull/1096#issuecomment-945158967).
 
@@ -247,9 +247,9 @@ alimentation . déchets . gestes . bonus acheter en vrac . gisement réduction:
 alimentation . déchets . gestes . bonus acheter en vrac . empreinte plastique:
   formule: 2.383
   unité: kgCO2e/kg
-  note: FE issu de la Base Carbone (Plastique - moyenne - neuf)
+  note: Facteur d'émission issu de la Base Carbone (Plastique - moyenne - neuf)
 
 alimentation . déchets . gestes . bonus acheter en vrac . empreinte carton:
   formule: 0.390
   unité: kgCO2e/kg
-  note: FE issu de la Base Carbone (Carton - neuf)
+  note: Facteur d'émission issu de la Base Carbone (Carton - neuf)

--- a/data/bilan.publicodes
+++ b/data/bilan.publicodes
@@ -23,6 +23,3 @@ bilan:
       - alimentation
       - divers
       - services sociétaux
-  références:
-    - https://avenirclimatique.org/action/
-    - https://www.statistiques.developpement-durable.gouv.fr/estimation-de-lempreinte-carbone-de-1995-2019?rubrique=27&dossier=1286

--- a/data/divers/numérique.publicodes
+++ b/data/divers/numérique.publicodes
@@ -176,10 +176,6 @@ divers . numérique . appareils . téléphone . empreinte:
   titre: Empreinte d'un téléphone
   icônes: 📱✨
   exposé: oui
-  références:
-    - https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Smartphone
-    - https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/produits_informatiques__electr
-    - https://www.apple.com/environment/pdf/products/iphone/iPhone_11_PER_sept2019.pdf
   note: |
     Dans la première version de Nos Gestes Climat nous segmentions les possibilités de cette question en trois catégorie, selon les disponibilités des données dans la base carbone et fabricants).
 
@@ -193,7 +189,12 @@ divers . numérique . appareils . téléphone . empreinte:
     Afin de simplifier le questionnaire, permettre de compter plusieurs téléphones (plusieurs achats sur les dernières années), 
     et au vu que les smartphones sont les téléphones majoritairement utilisés, nous avons fait l'hypothèse (plus conservatrice) 
     que l'empreinte de la construction d'un smartphone est plus proche de celle communiquée par Apple notamment 
-    (voir point ci-dessus pour l'obtention du chiffre de 57kg par unité)
+    (voir point ci-dessus pour l'obtention du chiffre de 57kg par unité).
+
+    Voir :
+      - https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Smartphone
+      - https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/produits_informatiques__electr
+      - https://www.apple.com/environment/pdf/products/iphone/iPhone_11_PER_sept2019.pdf
   formule: 57
   unité: kgCO2e
 

--- a/data/empreinte SDES/empreinte nationale.publicodes
+++ b/data/empreinte SDES/empreinte nationale.publicodes
@@ -9,7 +9,7 @@ empreinte SDES:
     et services adressés à la demande finale. L’origine des émissions de ces biens et services est identifiée et permet de
     distinguer les émissions de la production intérieure et celles associées aux importations. Les importations peuvent être adressées
     à la demande finale ou consommées par les activités économiques (matières premières, produits semi-finis).
-  réfrence:
+  note: |
     - https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021
     - https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2022-07/document_travail_59_decomposition_empreinte_carbone_juillet2022.pdf
   formule:
@@ -36,7 +36,7 @@ population:
   description: Correspond aux émissions directes des ménages (issues des carburants consommés par les véhicules individuels et des combustibles fossiles utilisés dans les chaudières des logements)
   formule: 120312.93489
   unité: ktCO2e
-  référence: https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021
+  note: Chiffre issu de [l'estimation de l'empreinte nationale française par le Ministère de l'Écologie](https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021)
 
 émissions hors direct ménages par hab:
   titre: Emissions hors direct ménages par habitant

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -90,29 +90,23 @@ alimentation . boisson . alcool . facteur:
   titre.auto: factor
   titre.lock: facteur
 alimentation . boisson . alcool . facteur bière:
-  note: |
-    FE from agribalysis, 1.12 kgCO2e/kg. The density of the beer is
-    considered to be 1kg/l.
-  note.auto: FE from agribalysis, 1.12 kgCO2e/kg. The density of the beer is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse, 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
+  note: FE from Agribalyse<a href="https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool">, core market beer</a>), 1.12 kgCO2e/kg. Beer density is assumed to be 1kg/l.
+  note.auto: FE from Agribalyse<a href="https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool">, core market beer</a>), 1.12 kgCO2e/kg. Beer density is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, bière coeur de marché](https://agribalyse.ademe.fr/app/aliments/5001#Bi%C3%A8re_%22coeur_de_march%C3%A9%22_(4-5%C2%B0_alcool)), 1.12 kgCO2e/kg. On considère que la masse volumique de la bière est de 1kg/l.
   titre: beer factor
   titre.auto: beer factor
   titre.lock: facteur bière
 alimentation . boisson . alcool . facteur coktail:
-  note: |
-    FE from agribalysis (punch type cocktail), 0.91 kgCO2e/kg. The density
-    of a cocktail is considered to be 1kg/l.
-  note.auto: FE from agribalysis (punch type cocktail), 0.91 kgCO2e/kg. The density of a cocktail is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse (coktail type punch), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
+  note: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum">, rum-based cocktail</a>, 0.91 kgCO2e/kg. The density of a coktail is assumed to be 1kg/l.
+  note.auto: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum">, rum-based cocktail</a>, 0.91 kgCO2e/kg. The density of a coktail is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, coktail base rhum](https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum), 0.91 kgCO2e/kg. On considère que la masse volumique d'un coktail est de 1kg/l.
   titre: coktail factor
   titre.auto: coktail factor
   titre.lock: facteur coktail
 alimentation . boisson . alcool . facteur vin:
-  note: |
-    FE from agribalysis, 1.22 kgCO2e/kg. The density of the wine is
-    considered to be 1kg/l.
-  note.auto: FE from agribalysis, 1.22 kgCO2e/kg. The density of the wine is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse, 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
+  note: FE from Agribalyse<a href="https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec">, dry white wine</a>, 1.22 kgCO2e/kg. Wine density is assumed to be 1kg/l.
+  note.auto: FE from Agribalyse<a href="https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec">, dry white wine</a>, 1.22 kgCO2e/kg. Wine density is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, vin blanc sec](https://agribalyse.ademe.fr/app/aliments/5215#Vin_blanc_sec), 1.22 kgCO2e/kg. On considère que la masse volumique du vin est de 1kg/l.
   titre: wine factor
   titre.auto: wine factor
   titre.lock: facteur vin
@@ -317,6 +311,9 @@ alimentation . boisson . eau en bouteille . empreinte:
   titre: footprint
   titre.auto: footprint
   titre.lock: empreinte
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source">, bottled spring water</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source">, bottled spring water</a>.
+  note.lock: FE issu d'[Agibalyse, eau embouteillée de source](https://agribalyse.ademe.fr/app/aliments/18430#Eau_embouteillée_de_source).
 alimentation . boisson . froide:
   titre: cold
   titre.auto: cold
@@ -343,29 +340,23 @@ alimentation . boisson . sucrées . facteur:
   titre.auto: factor
   titre.lock: facteur
 alimentation . boisson . sucrées . facteur jus de fruits:
-  note: |
-    FE from agribalysis (Multifruit juice, pure juice, standard), 0.91
-    kgCO2e/kg. Density is considered to be 1kg/l.
-  note.auto: FE from agribalysis (Multifruit juice, pure juice, standard), 0.91 kgCO2e/kg. Density is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse (Jus multifruit, pur jus, standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard">, Multifruit juice, pure juice, standard</a>, 0.91 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.auto: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard">, Multifruit juice, pure juice, standard</a>, 0.91 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, Jus multifruit, pur jus, standard](https://agribalyse.ademe.fr/app/aliments/2069#Jus_multifruit,_%C3%A0_base_de_concentr%C3%A9,_standard), 0.91 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
   titre: fruit juice factor
   titre.auto: fruit juice factor
   titre.lock: facteur jus de fruits
 alimentation . boisson . sucrées . facteur sirops:
-  note: |
-    FE from agribalysis, 0.10 kgCO2e/kg. The density is considered to be
-    1kg/l.
-  note.auto: FE from agribalysis, 0.10 kgCO2e/kg. The density is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse, 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau">, drink prepared from syrup</a>, 0.10 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.auto: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau">, drink prepared from syrup</a>, 0.10 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, boisson préparée à partir de sirop](https://agribalyse.ademe.fr/app/aliments/18058#Boisson_pr%C3%A9par%C3%A9e_%C3%A0_partir_de_sirop_%C3%A0_diluer_type_menthe,_fraise,_etc,_sucr%C3%A9,_dilu%C3%A9_dans_l'eau), 0.10 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
   titre: syrup factor
   titre.auto: syrup factor
   titre.lock: facteur sirops
 alimentation . boisson . sucrées . facteur sodas:
-  note: |
-    FE from agribalysis (Cola, sweet), 0.51 kgCO2e/kg. Density is considered
-    to be 1kg/l.
-  note.auto: FE from agribalysis (Cola, sweet), 0.51 kgCO2e/kg. Density is considered to be 1kg/l.
-  note.lock: FE issu d'agribalyse (Cola, sucré), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
+  note: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants">, Cola, sweet</a>, 0.51 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.auto: FE from Agribalysis<a href="https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants">, Cola, sweet</a>, 0.51 kgCO2e/kg. Density is assumed to be 1kg/l.
+  note.lock: FE issu d'[Agribalyse, Cola, sucré](https://agribalyse.ademe.fr/app/aliments/18037#Cola,_sucr%C3%A9,_avec_%C3%A9dulcorants), 0.51 kgCO2e/kg. On considère que la masse volumique est de 1kg/l.
   titre: soft drink factor
   titre.auto: soft drink factor
   titre.lock: facteur sodas
@@ -396,6 +387,9 @@ alimentation . boisson . tasse de café . empreinte café moulu:
   titre: ground coffee footprint
   titre.auto: ground coffee footprint
   titre.lock: empreinte café moulu
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu">, ground coffee</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu">, ground coffee</a>.
+  note.lock: FE issu d'[Agibalyse, café moulu](https://agribalyse.ademe.fr/app/aliments/18003#Caf%C3%A9,_moulu).
 alimentation . boisson . tasse de café . quantité café par tasse:
   note: it is assumed that a cup of coffee contains an average of 12 grams of ground coffee.
   note.auto: it is assumed that a cup of coffee contains an average of 12 grams of ground coffee.
@@ -411,6 +405,9 @@ alimentation . boisson . tasse de chocolat chaud . empreinte cacao en poudre:
   titre: cocoa powder imprint
   titre.auto: cocoa powder imprint
   titre.lock: empreinte cacao en poudre
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble">, unsweetened soluble cocoa</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble">, unsweetened soluble cocoa</a>.
+  note.lock: FE issu d'[Agibalyse, cacao non sucré soluble](https://agribalyse.ademe.fr/app/aliments/18100#Cacao,_non_sucr%C3%A9,_poudre_soluble).
 alimentation . boisson . tasse de chocolat chaud . empreinte lait:
   titre: milk footprint
   titre.auto: milk footprint
@@ -437,6 +434,9 @@ alimentation . boisson . tasse de thé . empreinte thé infusé:
   titre: infused tea print
   titre.auto: infused tea print
   titre.lock: empreinte thé infusé
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9">, unsweetened infused tea</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9">, unsweetened infused tea</a>.
+  note.lock: FE issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9).
 alimentation . boisson . tasse de thé . empreinte thé infusé sans consommation:
   note: |
     For the footprint of a cup of coffee or hot chocolate, the portion
@@ -467,6 +467,15 @@ alimentation . boisson . tasse de thé . part consommation empreinte thé infus�
   titre: share consumption footprint brewed tea
   titre.auto: share consumption footprint brewed tea
   titre.lock: part consommation empreinte thé infusé
+  note: |
+    According to the breakdown from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9">, unsweetened brewed tea</a>,
+    consumption accounts for 25% of the tea emission factor.
+  note.auto: |
+    According to the breakdown from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9">, unsweetened brewed tea</a>,
+    consumption accounts for 25% of the tea emission factor.
+  note.lock: |
+    Selon la décomposition issu d'[Agibalyse, thé infusé non sucré](https://agribalyse.ademe.fr/app/aliments/18020#Th%C3%A9_infus%C3%A9,_non_sucr%C3%A9),
+    la part de consommation dans le facteur d'émission du thé représente 25%.
 alimentation . boisson . tasse de thé . quantité thé par tasse:
   note: we assume that a cup of tea is on average 250 grams.
   note.auto: we assume that a cup of tea is on average 250 grams.
@@ -1912,6 +1921,9 @@ alimentation . déchets . gestes . bonus acheter en vrac . empreinte carton:
   titre: cardboard footprint
   titre.auto: cardboard footprint
   titre.lock: empreinte carton
+  note: EF from Base Carbone (Cardboard - new)
+  note.auto: EF from Base Carbone (Cardboard - new)
+  note.lock: FE issu de la Base Carbone (Carton - neuf)
 alimentation . déchets . gestes . bonus acheter en vrac . empreinte emballages évités:
   note: |
     Source: Page 47 of [the ADEME study](https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html)
@@ -1929,6 +1941,9 @@ alimentation . déchets . gestes . bonus acheter en vrac . empreinte plastique:
   titre: plastic footprint
   titre.auto: plastic footprint
   titre.lock: empreinte plastique
+  note: FE from Base Carbone (Plastics - average - new)
+  note.auto: FE from Base Carbone (Plastics - average - new)
+  note.lock: FE issu de la Base Carbone (Plastique - moyenne - neuf)
 alimentation . déchets . gestes . bonus acheter en vrac . gisement réduction:
   note: |
     Source: Page 47 of <a href="https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html">the ADEME study</a>
@@ -1971,6 +1986,9 @@ alimentation . déchets . gestes . empreinte gaspillage alimentaire:
   titre: food waste footprint
   titre.auto: food waste footprint
   titre.lock: empreinte gaspillage alimentaire
+  note: See table on page 111 of <a href="https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html">the ADEME study</a>
+  note.auto: See table on page 111 of <a href="https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html">the ADEME study</a>
+  note.lock: Voir tableau page 111 de [l'étude ADEME](https://librairie.ademe.fr/dechets-economie-circulaire/2520-etude-d-evaluation-des-gisements-d-evitement-des-potentiels-de-reduction-de-dechets-et-des-impacts-environnementaux-evites.html)
 alimentation . déchets . gestes . gaspillage alimentaire:
   note: |
     It should be noted that there is a double counting with the end of life of non combustible losses at the consumer already taken into account in the FE meals
@@ -2039,17 +2057,20 @@ alimentation . déchets . niveau moyen:
   titre.lock: niveau moyen
 alimentation . déchets . niveau zéro déchets:
   note: |
-    It is considered that the proportion of people actually living without generating any waste is not very representative even within the zero waste movement. Thus,
-    we consider that a zero waste lifestyle corresponds to a division by 4 of all the other quantities of waste (MSW, CS and landfill).
-    Only putrescible waste is excluded from the reductions made because it does not concern packaging.
+    Even within the zero-waste movement, the proportion of people who actually live a zero-waste lifestyle is not very representative. Therefore,
+    we consider that a zero-waste lifestyle corresponds to a division by 4 of all other waste quantities (household waste, household solid waste and landfill).
+    Only putrescible waste is excluded from these reductions, as it does not involve packaging.
+    See <a href="https://librairie.ademe.fr/dechets-economie-circulaire/1906-bien-vivre-en-zero-dechet.html">ADEME's Bien vivre en zéro déchet</a> analysis.
   note.auto: |
-    It is considered that the proportion of people actually living without generating any waste is not very representative even within the zero waste movement. Thus,
-    we consider that a zero waste lifestyle corresponds to a division by 4 of all the other quantities of waste (MSW, CS and landfill).
-    Only putrescible waste is excluded from the reductions made because it does not concern packaging.
+    Even within the zero-waste movement, the proportion of people who actually live a zero-waste lifestyle is not very representative. Therefore,
+    we consider that a zero-waste lifestyle corresponds to a division by 4 of all other waste quantities (household waste, household solid waste and landfill).
+    Only putrescible waste is excluded from these reductions, as it does not involve packaging.
+    See <a href="https://librairie.ademe.fr/dechets-economie-circulaire/1906-bien-vivre-en-zero-dechet.html">ADEME's Bien vivre en zéro déchet</a> analysis.
   note.lock: |
     On considère que la part de gens vivant réellement sans générer aucun déchets est peu représentative même au sein du mouvement zéro déchets. Ainsi,
     on considère qu'un mode de vie zéro déchets correspond à une division par 4 de toutes les autres quantitées de déchets (OMR, CS et déchetterie).
     Seuls les déchets putrescibles sont exclus des réduction opérées car ils ne concernent pas les emballages.
+    Voir l'analyse [Bien vivre en zéro déchet de l'ADEME](https://librairie.ademe.fr/dechets-economie-circulaire/1906-bien-vivre-en-zero-dechet.html).
   titre: zero waste level
   titre.auto: zero waste level
   titre.lock: niveau zéro déchets
@@ -2608,18 +2629,33 @@ alimentation . empreinte lait d'avoine:
   titre: oat milk
   titre.auto: oat milk
   titre.lock: lait d'avoine
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature">, a natural oat-based drink</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature">, a natural oat-based drink</a>.
+  note.lock: FE issu d'[Agibalyse, boisson à base d'avoine nature](https://agribalyse.ademe.fr/app/aliments/18905#Boisson_à_base_d'avoine,_nature).
 alimentation . empreinte lait de soja:
   titre: soy milk footprint
   titre.auto: soy milk footprint
   titre.lock: empreinte lait de soja
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature">, plain soy beverage</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature">, plain soy beverage</a>.
+  note.lock: FE issu d'[Agibalyse, boisson au soja nature](https://agribalyse.ademe.fr/app/aliments/18900#Boisson_au_soja,_nature).
 alimentation . empreinte lait de vache:
   titre: cow's milk footprint
   titre.auto: cow's milk footprint
   titre.lock: empreinte lait de vache
+  note: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9">, pasteurized semi-skimmed milk</a>.
+  note.auto: FE from Agibalyse<a href="https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9">, pasteurized semi-skimmed milk</a>.
+  note.lock: FE issu d'[Agibalyse, lait demi-écrémé pasteurisé](https://agribalyse.ademe.fr/app/aliments/19042#Lait_demi-%C3%A9cr%C3%A9m%C3%A9,_pasteuris%C3%A9).
 alimentation . gaspillage alimentaire:
-  note: In the referenced document, page 7 for the waste footprint and page 36 for the average reduction.
-  note.auto: In the referenced document, page 7 for the waste footprint and page 36 for the average reduction.
-  note.lock: Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
+  note: |
+    See the report on <a href="https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages">estimating the impact of household food waste</a>, 
+    page 7 for the waste footprint and page 36 for the average reduction.
+  note.auto: |
+    See the report on <a href="https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages">estimating the impact of household food waste</a>, 
+    page 7 for the waste footprint and page 36 for the average reduction.
+  note.lock: |
+    Voir le rapport sur [l'estimation des impacts du gaspillage alimentaire des ménages](https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages), 
+    page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
   titre: Reduce my food waste
   titre.auto: Reduce my food waste
   titre.lock: Réduire mon gaspillage alimentaire
@@ -5378,7 +5414,12 @@ divers . numérique . appareils . téléphone . empreinte:
     To simplify the questionnaire, allow several phones to be counted (several purchases in recent years), 
     and in view of the fact that smartphones are the phones most frequently used, we have made the (more conservative) assumption 
     that the footprint of a smartphone's construction is closer to that communicated by Apple in particular 
-    (see point above for the 57kg per unit figure)
+    (see point above for the 57kg per unit figure).
+
+    See
+      - https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Smartphone
+      - https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/produits_informatiques__electr
+      - https://www.apple.com/environment/pdf/products/iphone/iPhone_11_PER_sept2019.pdf
   note.auto: |
     In the first version of Nos Gestes Climat we divided the possibilities of this question into three categories, according to the availability of data in the carbon base and manufacturers).
 
@@ -5392,7 +5433,12 @@ divers . numérique . appareils . téléphone . empreinte:
     To simplify the questionnaire, allow several phones to be counted (several purchases in recent years), 
     and in view of the fact that smartphones are the phones most frequently used, we have made the (more conservative) assumption 
     that the footprint of a smartphone's construction is closer to that communicated by Apple in particular 
-    (see point above for the 57kg per unit figure)
+    (see point above for the 57kg per unit figure).
+
+    See
+      - https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Smartphone
+      - https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/produits_informatiques__electr
+      - https://www.apple.com/environment/pdf/products/iphone/iPhone_11_PER_sept2019.pdf
   note.lock: |
     Dans la première version de Nos Gestes Climat nous segmentions les possibilités de cette question en trois catégorie, selon les disponibilités des données dans la base carbone et fabricants).
 
@@ -5406,7 +5452,12 @@ divers . numérique . appareils . téléphone . empreinte:
     Afin de simplifier le questionnaire, permettre de compter plusieurs téléphones (plusieurs achats sur les dernières années), 
     et au vu que les smartphones sont les téléphones majoritairement utilisés, nous avons fait l'hypothèse (plus conservatrice) 
     que l'empreinte de la construction d'un smartphone est plus proche de celle communiquée par Apple notamment 
-    (voir point ci-dessus pour l'obtention du chiffre de 57kg par unité)
+    (voir point ci-dessus pour l'obtention du chiffre de 57kg par unité).
+
+    Voir :
+      - https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Smartphone
+      - https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/produits_informatiques__electr
+      - https://www.apple.com/environment/pdf/products/iphone/iPhone_11_PER_sept2019.pdf
   titre: Fingerprint of a phone
   titre.auto: Fingerprint of a phone
   titre.lock: Empreinte d'un téléphone
@@ -5871,6 +5922,12 @@ divers . publicité:
   titre: Ignore ads and sales
   titre.auto: Ignore ads and sales
   titre.lock: Ignorer les pubs et soldes
+  note: |
+    ADEME: https://librairie.ademe.fr/dechets-economie-circulaire/325-biens-d-equipement-benefices-environnementaux-d-allonger-leur-duree-de-vie.html
+  note.auto: |
+    ADEME: https://librairie.ademe.fr/dechets-economie-circulaire/325-biens-d-equipement-benefices-environnementaux-d-allonger-leur-duree-de-vie.html
+  note.lock: |
+    ADEME: https://librairie.ademe.fr/dechets-economie-circulaire/325-biens-d-equipement-benefices-environnementaux-d-allonger-leur-duree-de-vie.html
 divers . textile:
   description: |
     Tell us what you put in your shopping bags this year, or in a
@@ -6767,6 +6824,15 @@ empreinte SDES:
   titre: Carbon footprint per French person estimated by the SDES
   titre.auto: Carbon footprint per French person estimated by the SDES
   titre.lock: Empreinte carbone par français estimée par le SDES
+  note: |
+    - https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021
+    - https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2022-07/document_travail_59_decomposition_empreinte_carbone_juillet2022.pdf
+  note.auto: |
+    - https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021
+    - https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2022-07/document_travail_59_decomposition_empreinte_carbone_juillet2022.pdf
+  note.lock: |
+    - https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021
+    - https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2022-07/document_travail_59_decomposition_empreinte_carbone_juillet2022.pdf
 empreinte branche:
   description: Corresponds to the carbon intensity associated with each of the economic branches associated with the NAF nomenclature.
   description.auto: Corresponds to the carbon intensity associated with each of the economic branches associated with the NAF nomenclature.
@@ -15003,29 +15069,33 @@ fioul kWh au litre:
   titre.lock: fioul kWh au litre
 gaz:
   description: |
-    Here we calculate the price of gas from the consumption of a household
+    Here we calculate the price of gas based on household consumption. 
 
-    It is thus a question of including the various compulsory levies, as well as the really significant subscription in the case of gas
+    This means including the various compulsory levies, as well as the really significant subscription in the case of gas. 
 
-    Attention, the gas market is largely liberalized, so the regulated rate, which is the basis of our calculation, is no longer exclusive. We can no longer subscribe to it, but the existing customers will be until 2023
+    Please note that the gas market is largely liberalized, so the regulated tariff, which is the basis of our calculation, is no longer exclusive. We can no longer subscribe to it, but existing customers will continue to do so until 2023. 
 
-    In 2023, there are two types of tariffs: the one that is indexed on the regulated tariff, which is very close to it, and the completely free tariffs, often fixed for a determined period.
+    In 2023, there will be two types of tariff: one indexed to the regulated tariff, which is very close to it, and completely free tariffs, often fixed for a specific period.
 
-    We therefore assume that the regulated tariff remains representative of the price of an average household
+    We therefore assume that the regulated tariff remains representative of the price for an average household. 
 
     Source for <a href="https://www.energie-info.fr/fiche_pratique/cspe-ticgn-cta-tva-toutes-les-taxes-sur-ma-facture/">the list of taxes</a>.
+
+    See also: https://tarifgaz.com/tarifs
   description.auto: |
-    Here we calculate the price of gas from the consumption of a household. 
+    Here we calculate the price of gas based on household consumption. 
 
-    It is thus a question of including the various obligatory levies, as well as the really significant subscription in the case of gas. 
+    This means including the various compulsory levies, as well as the really significant subscription in the case of gas. 
 
-    Attention, the gas market is largely liberalized, so the regulated rate, which is the basis of our calculation, is no longer exclusive. We can no longer subscribe to it, but the existing customers will be until 2023. 
+    Please note that the gas market is largely liberalized, so the regulated tariff, which is the basis of our calculation, is no longer exclusive. We can no longer subscribe to it, but existing customers will continue to do so until 2023. 
 
-    In 2023, there are two types of tariffs: the one that is indexed on the regulated tariff, which is very close to it, and the completely free tariffs, often fixed for a determined period.
+    In 2023, there will be two types of tariff: one indexed to the regulated tariff, which is very close to it, and completely free tariffs, often fixed for a specific period.
 
-    We therefore assume that the regulated tariff remains representative of the price of an average household. 
+    We therefore assume that the regulated tariff remains representative of the price for an average household. 
 
     Source for <a href="https://www.energie-info.fr/fiche_pratique/cspe-ticgn-cta-tva-toutes-les-taxes-sur-ma-facture/">the list of taxes</a>.
+
+    See also: https://tarifgaz.com/tarifs
   description.lock: |
     Nous calculons ici le prix du gaz à partir de la consommation d'un foyer. 
 
@@ -15038,6 +15108,8 @@ gaz:
     Nous partons donc du principe que le tarif reglementé reste représentatif du prix d'un foyer moyen. 
 
     Source pour [la liste des taxes](https://www.energie-info.fr/fiche_pratique/cspe-ticgn-cta-tva-toutes-les-taxes-sur-ma-facture/).
+
+    Voir également: https://tarifgaz.com/tarifs
   titre: Help calculating gas consumption
   titre.auto: Help calculating gas consumption
   titre.lock: Aide calcul consommation gaz
@@ -15250,13 +15322,13 @@ logement . appartement:
 
     > Si vous vivez dans un habitat original, par exemple un camping-car / un camion / une péniche, pas de problème : choisissez "appartement" et saisissez les m² de ce qui constitue quand même votre logement.
   note: |
-    > In 2018, single-family dwellings accounted for 56% of all housing units: the majority of both primary residences and secondary and occasional homes. After rising between 1999 and 2008, its share is declining slightly, as the number of multi-family homes is increasing faster than that of single-family homes, due to recent trends in new construction.
+    In 2018, single-family homes accounted for 56% of all housing units ( <a href="https://www.insee.fr/fr/statistiques/3676693?sommaire=3696937">Source: INSEE</a>): the majority of both primary residences and secondary and occasional homes. After increasing between 1999 and 2008, its share is declining slightly, as the number of multi-family dwellings is increasing faster than that of single-family dwellings due to recent trends in new construction.
     It should be noted that this is a proportion of dwellings; however, it can be expected (to be verified) that houses contain more people on average than apartments, which reinforces the choice of the default value.
   note.auto: |
-    > In 2018, single-family dwellings accounted for 56% of all housing units: the majority of both primary residences and secondary and occasional homes. After rising between 1999 and 2008, its share is declining slightly, as the number of multi-family homes is increasing faster than that of single-family homes, due to recent trends in new construction.
+    In 2018, single-family homes accounted for 56% of all housing units ( <a href="https://www.insee.fr/fr/statistiques/3676693?sommaire=3696937">Source: INSEE</a>): the majority of both primary residences and secondary and occasional homes. After increasing between 1999 and 2008, its share is declining slightly, as the number of multi-family dwellings is increasing faster than that of single-family dwellings due to recent trends in new construction.
     It should be noted that this is a proportion of dwellings; however, it can be expected (to be verified) that houses contain more people on average than apartments, which reinforces the choice of the default value.
   note.lock: |
-    > En 2018, l’habitat individuel représente 56 % des logements : il est majoritaire parmi les résidences principales comme parmi les résidences secondaires et logements occasionnels. Après avoir progressé entre 1999 et 2008 sa part recule légèrement, car le nombre de logements collectifs augmente plus vite que celui des logements individuels du fait des évolutions récentes de la construction neuve.
+    En 2018, l’habitat individuel représente 56 % des logements ([Source INSEE](https://www.insee.fr/fr/statistiques/3676693?sommaire=3696937)) : il est majoritaire parmi les résidences principales comme parmi les résidences secondaires et logements occasionnels. Après avoir progressé entre 1999 et 2008 sa part recule légèrement, car le nombre de logements collectifs augmente plus vite que celui des logements individuels du fait des évolutions récentes de la construction neuve.
     Notons qu'il s'agit d'une proportion de logements ; or on peut s'attendre (à vérifier) à ce que les maisons contiennent davantage de gens en moyenne que les appartements, ce qui renforce le choix de la valeur par défaut.
   question: Is your home a flat?
   question.auto: Is your home an apartment?
@@ -15488,6 +15560,9 @@ logement . chauffage . bois . type:
   titre: type of wood
   titre.auto: type of wood
   titre.lock: type de bois
+  note: Log-burning stoves account for <a href="https://www.planetoscope.com/Source-d-energie/1521-.html">70% of all stoves sold</a>.
+  note.auto: Log-burning stoves account for <a href="https://www.planetoscope.com/Source-d-energie/1521-.html">70% of all stoves sold</a>.
+  note.lock: Les poêles à bûches représentent [70% des poêles vendus](https://www.planetoscope.com/Source-d-energie/1521-.html).
 logement . chauffage . bois . type . bûche:
   titre: Logs
   titre.auto: Logs
@@ -15542,15 +15617,9 @@ logement . chauffage . bois . type . bûche . consommation . saisie:
   titre.auto: input
   titre.lock: saisie
 logement . chauffage . bois . type . bûche . intensité énergétique:
-  note: |
-    We assume a log consumption of 20% moisture content.
-    Source: in the ZIP file (!) below, file 1_chauffage_domestique_bois_appro_rapport.pdf page 10.
-  note.auto: |
-    We assume a log consumption of 20% moisture content.
-    Source: in the ZIP file (!) below, file 1_chauffage_domestique_bois_appro_rapport.pdf page 10.
-  note.lock: |
-    Nous faisons l'hypothèse d'une consommation de bûches de 20% d'humidité.
-    Source : dans le fichier ZIP (!) ci-dessous, fichier 1_chauffage_domestique_bois_appro_rapport.pdf page 10.
+  note: We have assumed consumption of logs with a moisture content of 20%, according to the<a href="https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html">ADEME</a> study<a href="https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html">on domestic wood heating</a>, page 10.
+  note.auto: We have assumed consumption of logs with a moisture content of 20%, according to the<a href="https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html">ADEME</a> study<a href="https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html">on domestic wood heating</a>, page 10.
+  note.lock: Nous faisons l'hypothèse d'une consommation de bûches de 20% d'humidité, d'après l'[étude ADEME sur le chauffahe domestique au bois](https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html), page 10.
   titre: energy intensity
   titre.auto: energy intensity
   titre.lock: intensité énergétique
@@ -15831,6 +15900,24 @@ logement . chauffage . fioul . estimation via le prix:
   titre: estimation via price
   titre.auto: estimation via price
   titre.lock: estimation via le prix
+  note: |
+    This formula allows us to switch from €/month to liters/year.
+
+    Source: Heating oil 2000 to 4999 liters, 2nd semester 2022.
+    Data taken from excel <a href="https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx">Prices ex VAT and inc VAT since January 2020.xlsx</a>
+    downloadable from the French Ministry of Ecological Transition's <a href="https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4">Petroleum Product Prices</a> page.
+  note.auto: |
+    This formula allows us to switch from €/month to liters/year.
+
+    Source: Heating oil 2000 to 4999 liters, 2nd semester 2022.
+    Data taken from excel <a href="https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx">Prices ex VAT and inc VAT since January 2020.xlsx</a>
+    downloadable from the French Ministry of Ecological Transition's <a href="https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4">Petroleum Product Prices</a> page.
+  note.lock: |
+    Cette formule nous permet de passer des €/mois aux litres/an.
+
+    Source : Fioul domestique 2000 à 4999 litres, 2ème semestre 2022.
+    Donnée issue de l'excel [Prix HTT et TTC depuis janvier 2020.xlsx](https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx)
+    téléchargeable sur la page [Prix des produits pétroliers](https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4) du ministère de la Transition Écologique.
 logement . chauffage . fioul . présent:
   question: Is your home heated with oil?
   question.auto: Is your home heated with oil?
@@ -15956,10 +16043,22 @@ logement . chauffage . intensité carbone GPL:
   titre: carbon intensity LPG
   titre.auto: carbon intensity LPG
   titre.lock: intensité carbone GPL
+  note: |
+    EF from Base Carbone (LPG for road vehicles). 
+    There is no "in-house" LPG in the Base Carbone. Could a solution be to point directly to the natural gas EF?
+  note.auto: |
+    EF from Base Carbone (LPG for road vehicles). 
+    There is no "in-house" LPG in the Base Carbone. Could a solution be to point directly to the natural gas EF?
+  note.lock: |
+    FE issu de le Base Carbone (GPL pour véhicule routier). 
+    Il n'y a pas de GPL de "maison" dans la Base Carbone. Une solution pourrait être de pointer directement sur le FE gaz naturel ?
 logement . chauffage . intensité carbone fioul litre:
   titre: carbon intensity of fuel oil liter
   titre.auto: carbon intensity of fuel oil liter
   titre.lock: intensité carbone fioul litre
+  note: EF from Base Carbone (domestic heating oil in continental France).
+  note.auto: EF from Base Carbone (domestic heating oil in continental France).
+  note.lock: FE issu de la Base Carbone (Fioul domestique France continental).
 logement . chauffage . réseau de chaleur . intensité carbone:
   note: EF derived from the average of all the heating networks in the Carbon Base
   note.auto: EF derived from the average of all the heating networks in the Carbon Base
@@ -16310,33 +16409,75 @@ logement . construction . annuelle et par surface:
   titre.lock: annuelle et par surface
 logement . construction . durée d'amortissement:
   note: |
-    These values take into account the maintenance and possible replacement of products and equipment during the life of the building, which is set at 50 years.
+    The lifespan of a building is set at 50 years (see <a href="https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/">empreinte documentation, Asset Purchases/Buildings tab</a>).
   note.auto: |
-    These values take into account the maintenance and possible replacement of products and equipment during the life of the building, which is set at 50 years.
+    The lifespan of a building is set at 50 years (see <a href="https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/">empreinte documentation, Asset Purchases/Buildings tab</a>).
   note.lock: |
-    Ces valeurs tiennent compte de l’entretien et de l’éventuel remplacement des produits et équipements durant la vie du bâtiment fixée à 50 ans.
+    La durée de vie d'un bâtiment est fixée à 50 ans (voir la [documentation de la base empreinte, onglet Achats de bien/ Bâtiments](https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/)).
   titre: amortization period
   titre.auto: amortization period
   titre.lock: durée d'amortissement
 logement . construction . par surface:
   note: |
-    Note that for eco-built housing, the stored biogenic CO₂ is not accounted for, only the fossil CO₂ emitted is.
+    The carbon base entry does not provide further information on this category of construction method. Please refer to the <a href="https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/">documentation of the footprint database, tab Purchases of goods/Buildings</a>.
 
-    For the eco-built housing, we retain the emission factor of the carbon base, but it seems to be confirmed in order of magnitude in the Carbone 4 study.
+    The emission factor is entitled "Eco-built house", but for lack of information we assume it is the same for an eco-built apartment.
 
-    &gt; Gains observed on the fossil CO₂ of the structural work (foundations and structure), compared to concrete. Carbon storage in the wood product is not taken into account.  Gains linked to material substitution: CLT wood building: 118 kgCO2e/m2 SHON, i.e. 473 kgCO2e/m3 of wood product. MI wood frame: 83 kgCO2e/m2 SHON, i.e. 2495 kgCO2e/m3 of wood product. LC wood CLT: 231 kgCO2e/m2 SHON, or 699 kgCO2e/m3 of wood product. LC wood frame: 139 kgCO2e/m2 SHON, i.e. 3172 kgCO2e/m3 of wood product.
+    However, <a href="https://www.carbone4.com/sauver-le-climat-avec-nos-forets-la-construction-touche-du-bois-2">this Carbone 4 study</a> claims a 55% reduction from concrete to wood for the house, and 60% for the apartment.
+
+    Note that for eco-built housing, the biogenic CO₂ stored is not accounted for, only the fossil CO₂ emitted is.
+
+    For eco-built housing, we retain the emission factor from the carbon base, but it appears to be confirmed in order of magnitude in the Carbone 4 study.
+
+    > Gains observed on the fossil CO₂ of the shell item (foundations and structure), compared with concrete. 
+
+    Carbon storage in the wood product is not taken into account.
+
+    Gains linked to material substitution: 
+     - MI wood CLT: 118 kgCO2e/m2 SHON, i.e. 473 kgCO2e/m3 of wood product. 
+     - MI wood frame: 83 kgCO2e/m2 SHON, i.e. 2495 kgCO2e/m3 of wood product. 
+     - LC wood CLT: 231 kgCO2e/m2 SHON, i.e. 699 kgCO2e/m3 wood product.
+     - LC wood framing: 139 kgCO2e/m2 SHON, i.e. 3172 kgCO2e/m3 of wood product.
   note.auto: |
-    Note that for eco-built housing, the stored biogenic CO₂ is not accounted for, only the fossil CO₂ emitted is.
+    The carbon base entry does not provide further information on this category of construction method. Please refer to the <a href="https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/">documentation of the footprint database, tab Purchases of goods/Buildings</a>.
 
-    For the eco-built housing, we retain the emission factor of the carbon base, but it seems to be confirmed in order of magnitude in the Carbone 4 study.
+    The emission factor is entitled "Eco-built house", but for lack of information we assume it is the same for an eco-built apartment.
 
-    > Gains observed on the fossil CO₂ of the structural work (foundations and structure), compared to concrete. Carbon storage in the wood product is not taken into account.  Gains linked to material substitution: CLT wood building: 118 kgCO2e/m2 SHON, i.e. 473 kgCO2e/m3 of wood product. MI wood frame: 83 kgCO2e/m2 SHON, i.e. 2495 kgCO2e/m3 of wood product. LC wood CLT: 231 kgCO2e/m2 SHON, or 699 kgCO2e/m3 of wood product. LC wood frame: 139 kgCO2e/m2 SHON, i.e. 3172 kgCO2e/m3 of wood product.
+    However, <a href="https://www.carbone4.com/sauver-le-climat-avec-nos-forets-la-construction-touche-du-bois-2">this Carbone 4 study</a> claims a 55% reduction from concrete to wood for the house, and 60% for the apartment.
+
+    Note that for eco-built housing, the biogenic CO₂ stored is not accounted for, only the fossil CO₂ emitted is.
+
+    For eco-built housing, we retain the emission factor from the carbon base, but it appears to be confirmed in order of magnitude in the Carbone 4 study.
+
+    > Gains observed on the fossil CO₂ of the shell item (foundations and structure), compared with concrete. 
+
+    Carbon storage in the wood product is not taken into account.
+
+    Gains linked to material substitution: 
+     - MI wood CLT: 118 kgCO2e/m2 SHON, i.e. 473 kgCO2e/m3 of wood product. 
+     - MI wood frame: 83 kgCO2e/m2 SHON, i.e. 2495 kgCO2e/m3 of wood product. 
+     - LC wood CLT: 231 kgCO2e/m2 SHON, i.e. 699 kgCO2e/m3 wood product.
+     - LC wood framing: 139 kgCO2e/m2 SHON, i.e. 3172 kgCO2e/m3 of wood product.
   note.lock: |
+    L'entrée dans la base carbone ne donne pas plus d'informations sur cette catégorie de méthode de construction. Voir la [documentation de la base empreinte, onglet Achats de bien/ Bâtiments](https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/).
+
+    Le facteur d'émission titre "Maison éco-construite", faute d'informations nous considérons qu'il est le même pour un appartement éco-construit.
+
+    Cependant, [cette étude de Carbone 4](https://www.carbone4.com/sauver-le-climat-avec-nos-forets-la-construction-touche-du-bois-2) affirme un réduction de 55% du béton au bois pour la maison, et de 60% pour l'appartement.
+
     Notons que pour le logement éco-construit, le CO₂ biogénique stocké n'est pas comptabilisé, seul le CO₂ fossile émis l'est.
 
     Pour le logement éco-construit, nous retenons le facteur d'émission de la base carbone, mais il semble confirmé en ordre de grandeur dans l'étude Carbone 4.
 
-    > Gains observés sur le CO₂ fossile du poste gros-œuvre (fondations et structure), en comparaison au béton. Le stockage de carbone dans le produit  bois  n’est  pas  pris  en  compte.  Gains  liés  à  la  substitution  matériau  :  MI  bois  CLT  :  118  kgCO2e/m2  SHON,  soit  473  kgCO2e/m3  de produit bois. MI bois ossature : 83 kgCO2e/m2 SHON, soit 2495 kgCO2e/m3 de produit bois. LC bois CLT : 231 kgCO2e/m2 SHON, soit 699 kgCO2e/m3 de produit bois. LC bois ossature : 139 kgCO2e/m2 SHON, soit 3172 kgCO2e/m3 de produit bois.
+    > Gains observés sur le CO₂ fossile du poste gros-œuvre (fondations et structure), en comparaison au béton. 
+
+    Le stockage de carbone dans le produit bois n’est pas pris en compte.
+
+    Gains liés à la substitution matériau: 
+     - MI bois CLT: 118 kgCO2e/m2 SHON, soit 473 kgCO2e/m3 de produit bois. 
+     - MI bois ossature : 83 kgCO2e/m2 SHON, soit 2495 kgCO2e/m3 de produit bois. 
+     - LC bois CLT : 231 kgCO2e/m2 SHON, soit 699 kgCO2e/m3 de produit bois.
+     - LC bois ossature : 139 kgCO2e/m2 SHON, soit 3172 kgCO2e/m3 de produit bois.
   titre: per surface
   titre.auto: per surface
   titre.lock: par surface
@@ -16370,10 +16511,13 @@ logement . empreinte par défaut chauffage air:
 logement . gain rénovation:
   note: |
     Average energy gain after renovation on an ANAH program of 13,000 homes targeting "thermal flats".
+    More information on the <a href="https://france-renov.gouv.fr/aides/mpr/serenite">MaPrimeRénov' Sérénité</a> program (ex Habiter Mieux de L'Anah).
   note.auto: |
     Average energy gain after renovation on an ANAH program of 13,000 homes targeting "thermal flats".
+    More information on the <a href="https://france-renov.gouv.fr/aides/mpr/serenite">MaPrimeRénov' Sérénité</a> program (ex Habiter Mieux de L'Anah).
   note.lock: |
     Gain énergétique moyen après rénovation sur un programme de l'ANAH de 13 000 logements ciblant les "passoires thermiques".
+    Plus d'informations dans le programme [MaPrimeRénov’ Sérénité](https://france-renov.gouv.fr/aides/mpr/serenite) (ex Habiter Mieux de L’Anah).
   titre: renovation gain
   titre.auto: renovation gain
   titre.lock: gain rénovation
@@ -16508,9 +16652,18 @@ logement . pompe à chaleur . coefficient COP:
     For 1kWh of electricity consumed, how many kWh of heat are supplied?
   description.auto: For 1kWh of electricity consumed, how many kWh of heat are supplied?
   description.lock: Pour 1kWh d'électricité consommée, combien de kWh de chaleur fournis ?
-  note: We choose a conservative coefficient (the ADEME advises a COP &gt; 3).
-  note.auto: We choose a conservative coefficient (the ADEME advises a COP > 3).
-  note.lock: Nous choississons un coefficient conservateur (l'ADEME conseille un COP > 3).
+  note: |
+    We choose a conservative coefficient (ADEME recommends COP > 3).
+    See the <a href="https://particulier.edf.fr/fr/accueil/guide-energie/electricite/pompe-a-chaleur.html">EDF Guide</a>.
+    For more information, see the article <a href="https://conseils-thermiques.org/contenu/pompe-a-chaleur-ou-radiateur-electrique.php">Heat pump or electric radiators?</a>
+  note.auto: |
+    We choose a conservative coefficient (ADEME recommends COP > 3).
+    See the <a href="https://particulier.edf.fr/fr/accueil/guide-energie/electricite/pompe-a-chaleur.html">EDF Guide</a>.
+    For more information, see the article <a href="https://conseils-thermiques.org/contenu/pompe-a-chaleur-ou-radiateur-electrique.php">Heat pump or electric radiators?</a>
+  note.lock: |
+    Nous choississons un coefficient conservateur (l'ADEME conseille un COP > 3).
+    Voir le [Guide EDF](https://particulier.edf.fr/fr/accueil/guide-energie/electricite/pompe-a-chaleur.html).
+    Plus d'informations également sur l'article [Pompe à chaleur ou radiateurs électriques ?](https://conseils-thermiques.org/contenu/pompe-a-chaleur-ou-radiateur-electrique.php)
   titre: Actual coefficient of performance
   titre.auto: Actual coefficient of performance
   titre.lock: Coefficient de performance réel
@@ -16693,17 +16846,23 @@ logement . remplacer gaz par PAC:
 
     > Bonus : s'il fait trop chaud chez vous l'été, certaines PAC peuvent inverser leur fonctionnement et faire office de climatisation l'été.
   note: |
-    For now, we consider that replacing gas kWh with the same amount of electric kWh is a good first-order approximation. We will be able to adapt it later on according to the performance of residential installations.
+    For the time being, we consider the replacement of gas kWh by the same amount of electricity kWh to be a good first-order approximation. We can then adapt it to the performance of residential installations.
 
-    This action figures the replacement of the gas boiler, if you also heat your water with gas it will be necessary to choose a heat pump that can also heat water.
+    If you also heat your water with gas, you'll need to choose a heat pump that can also heat water.
+
+    See <a href="https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-installer-une-pompe-a-chaleur.pdf">ADEME PAC Guide</a>
   note.auto: |
-    For now, we consider that replacing gas kWh with the same amount of electric kWh is a good first-order approximation. We will be able to adapt it later on according to the performance of residential installations.
+    For the time being, we consider the replacement of gas kWh by the same amount of electricity kWh to be a good first-order approximation. We can then adapt it to the performance of residential installations.
 
-    This action figures the replacement of the gas boiler, if you also heat your water with gas it will be necessary to choose a heat pump that can also heat water.
+    If you also heat your water with gas, you'll need to choose a heat pump that can also heat water.
+
+    See <a href="https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-installer-une-pompe-a-chaleur.pdf">ADEME PAC Guide</a>
   note.lock: |
     Nous considérons pour l'instant que le remplacement des kWh de gaz par la même quantité de kWh électrique est une bonne approximation de premier ordre. Nous pourrons par la suite l'adapter en fonction du rendement des installations résidentielles.
 
     Cette action chiffre le remplacement de la chaudière gaz, si vous chauffez aussi votre eau au gaz il faudra choisir une PAC qui peut aussi chauffer l'eau.
+
+    Voir [Guide ADEME PAC](https://www.ademe.fr/sites/default/files/assets/documents/guide-pratique-installer-une-pompe-a-chaleur.pdf)
   titre: Switch from gas boiler to heat pump
   titre.auto: Switch from gas boiler to heat pump
   titre.lock: Passer de chaudière gaz à pompe à chaleur
@@ -16841,18 +17000,15 @@ logement . température:
   titre.lock: température
 logement . âge:
   description: |
-    In France, 24% of the housing stock was built before 1949 and 24%
-    between 1949 and 1974.
+    In France, 24% of the housing stock dates from before 1949 and 24% from between 1949 and 1974, according to <a href="https://www.insee.fr/fr/statistiques/fichier/2586377/LOGFRA17.pdf">INSEE</a>.
 
-    For Paris, [this](https://www.comeetie.fr/galerie/BatiParis) interactive
-    [map](https://www.comeetie.fr/galerie/BatiParis) is fascinating if you
-    are interested in the age of its housing.
+    For Paris, <a href="https://www.comeetie.fr/galerie/BatiParis">this</a> interactive <a href="https://www.comeetie.fr/galerie/BatiParis">map</a> is fascinating if you're interested in the age of its housing stock.
   description.auto: |
-    In France, 24% of the housing stock was built before 1949 and 24% between 1949 and 1974.
+    In France, 24% of the housing stock dates from before 1949 and 24% from between 1949 and 1974, according to <a href="https://www.insee.fr/fr/statistiques/fichier/2586377/LOGFRA17.pdf">INSEE</a>.
 
-    For Paris, <a href="https://www.comeetie.fr/galerie/BatiParis">this</a> interactive <a href="https://www.comeetie.fr/galerie/BatiParis">map</a> is fascinating if you are interested in the age of its housing.
+    For Paris, <a href="https://www.comeetie.fr/galerie/BatiParis">this</a> interactive <a href="https://www.comeetie.fr/galerie/BatiParis">map</a> is fascinating if you're interested in the age of its housing stock.
   description.lock: |
-    En France, 24% du parc de logements date d'avant 1949 et 24% entre 1949 et 1974.
+    En France, 24% du parc de logements date d'avant 1949 et 24% entre 1949 et 1974 selon l'[INSEE](https://www.insee.fr/fr/statistiques/fichier/2586377/LOGFRA17.pdf).
 
     Pour Paris, [cette carte](https://www.comeetie.fr/galerie/BatiParis) interactive est fascinante si la question de l'âge de ses logements vous intéresse.
   question: How old is your home?
@@ -16905,11 +17061,17 @@ logement . éclairage . avec LED:
   description.auto: Electricity consumption in a scenario with LED bulbs.
   description.lock: Consommation d'électricité dans un scénario avec ampoules LED.
   note: |
-    6.43 is the ratio between the annual consumption of 10 bulbs 60W (450kWh) vs 10 LEDs equivalent 60W (70kWh).
+    6.43 is the ratio between the annual power consumption of 10 60W bulbs (450kWh) vs. 10 LED 60W equivalent (70kWh).
+
+    Figure taken from <a href="https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf">Réduire sa facture d'électricité, June 2019, ADEME</a>
   note.auto: |
-    6.43 is the ratio between the annual consumption of 10 bulbs 60W (450kWh) vs 10 LEDs equivalent 60W (70kWh).
+    6.43 is the ratio between the annual power consumption of 10 60W bulbs (450kWh) vs. 10 LED 60W equivalent (70kWh).
+
+    Figure taken from <a href="https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf">Réduire sa facture d'électricité, June 2019, ADEME</a>
   note.lock: |
     6.43, c'est le rapport entre la conso annuelle de 10 ampoules 60W (450kWh) vs 10 LED équivalent 60 W (70kWh).
+
+    Chiffre issu du guide [Réduire sa facture d’électricité, Juin 2019, ADEME](https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf)
   titre: with LED
   titre.auto: with LED
   titre.lock: avec LED
@@ -16921,6 +17083,12 @@ logement . éclairage . consommation de l'éclairage:
   titre: Lighting in the electricity bill
   titre.auto: Lighting in the electricity bill
   titre.lock: Éclairage dans la facture d'électricité
+  note: |
+    Figure taken from the guide <a href="https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf">Réduire sa facture d'électricité, June 2019, ADEME</a>
+  note.auto: |
+    Figure taken from the guide <a href="https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf">Réduire sa facture d'électricité, June 2019, ADEME</a>
+  note.lock: |
+    Chiffre issu du guide [Réduire sa facture d’électricité, Juin 2019, ADEME](https://librairie.ademe.fr/cadic/7232/guide-pratique-reduire-facture-electricite.pdf)
 logement . éco-construit:
   question: Is your home made of wood, straw, stone or earth (eco-built)?
   question.auto: Is your home made of wood, straw, stone or earth (eco-built)?
@@ -16956,18 +17124,23 @@ logement . électricité . consommation:
   titre.lock: consommation
 logement . électricité . estimation via le coût:
   description: |
-    This formula allows us to go from €/month to kWh/year.
+    This formula enables us to switch from €/month to kWh/year.
 
-    The figure includes a subscription cost, and therefore represents an
-    average. It is not the marginal kWh price. It includes taxes.
+    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
+
+    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
   description.auto: |
-    This formula allows us to go from €/month to kWh/year.
+    This formula enables us to switch from €/month to kWh/year.
 
-    The figure includes a subscription cost, and therefore represents an average. It is not the marginal kWh price. It includes taxes.
+    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
+
+    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
   description.lock: |
     Cette formule nous permet de passer des €/mois aux kWh/an.
 
     Le chiffre inclut un coût de l'abonnement, et représente donc une moyenne. Ce n'est pas le prix du kWh marginal. Il inclut les taxes.
+
+    Chiffre issu de [Eurostat, household, second half 2021](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics).
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
   question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
@@ -17116,6 +17289,9 @@ parc français:
   titre: french park
   titre.auto: french park
   titre.lock: parc français
+  note: This model is based on the Ceren and SDES dataset <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">Energy consumption by residential use</a>.
+  note.auto: This model is based on the Ceren and SDES dataset <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">Energy consumption by residential use</a>.
+  note.lock: Ce modèle est basé sur le jeu de données du Ceren et SDES [Consommation d'énergie par usage du résidentiel](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel).
 parc français . chauffage:
   note: |
     Consumption for domestic hot water (DHW) and cooking are also included in the consumption figures.
@@ -18322,6 +18498,12 @@ transport . boulot . covoiturage:
   titre: Carpool to work
   titre.auto: Carpooling to work
   titre.lock: Aller au travail en covoiturage
+  note: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car-sharing become a sustainable mode of transport?</a>
+  note.auto: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car-sharing become a sustainable mode of transport?</a>
+  note.lock: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122)
 transport . boulot . distance:
   titre: distance
   titre.auto: distance
@@ -18520,9 +18702,9 @@ transport . bus . impact par km:
   titre.auto: impact per km
   titre.lock: impact par km
 transport . bus . vitesse:
-  note: Assumption of 12 km/h average speed, Paris City Hall, consulted on 05/09/2014
-  note.auto: Assumption of 12 km/h average speed, Paris City Hall, consulted on 05/09/2014
-  note.lock: Hypothèse de 12 km/h de vitesse moyenne, Mairie de Paris, consulté le 05/09/2014
+  note: Assumption of 12 km/h average speed.
+  note.auto: Assumption of 12 km/h average speed.
+  note.lock: Hypothèse de 12 km/h de vitesse moyenne.
   titre: speed
   titre.auto: speed
   titre.lock: vitesse
@@ -18548,6 +18730,12 @@ transport . covoiturage:
   titre: Favour carpooling
   titre.auto: Favour carpooling
   titre.lock: Privilégier le covoiturage
+  note: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car-sharing become a sustainable mode of transport?</a>
+  note.auto: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car-sharing become a sustainable mode of transport?</a>
+  note.lock: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122)
 transport . distance moyenne aller-retour trajet court:
   titre: average round trip distance short trip
   titre.auto: average round trip distance short trip
@@ -18591,6 +18779,12 @@ transport . km autoroute:
   titre: km highway
   titre.auto: km highway
   titre.lock: km autoroute
+  note: |
+    Interesting twitter feed on the subject: https://twitter.com/Tomsawy22670318/status/1274257124701462528.
+  note.auto: |
+    Interesting twitter feed on the subject: https://twitter.com/Tomsawy22670318/status/1274257124701462528.
+  note.lock: |
+    Fil twitter intéressant sur le sujet: https://twitter.com/Tomsawy22670318/status/1274257124701462528.
 transport . métro ou tram:
   description: |
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
@@ -18641,9 +18835,9 @@ transport . métro ou tram . impact par km:
   titre.auto: impact per km
   titre.lock: impact par km
 transport . métro ou tram . vitesse:
-  note: Assumption of 25 km/h average speed, transports.blog.lemonde.fr, accessed on 05/09/2014
-  note.auto: Assumption of 25 km/h average speed, transports.blog.lemonde.fr, accessed on 05/09/2014
-  note.lock: Hypothèse de 25 km/h de vitesse moyenne, transports.blog.lemonde.fr, consulté le 05/09/2014
+  note: Assumption of 25 km/h average speed, according to the article <a href="http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/">Les petits secrets de la RATP révélés au public (RATP's little secrets revealed to the public</a>)
+  note.auto: Assumption of 25 km/h average speed, according to the article <a href="http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/">Les petits secrets de la RATP révélés au public (RATP's little secrets revealed to the public</a>)
+  note.lock: Hypothèse de 25 km/h de vitesse moyenne, d'après l'article [Les petits secrets de la RATP révélés au public](http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/)
   titre: speed
   titre.auto: speed
   titre.lock: vitesse
@@ -18677,23 +18871,26 @@ transport . prendre moins l'avion:
   titre.lock: Prendre deux fois moins l'avion
 transport . réduction covoiturage:
   description: |
-    One might naively think that carpooling divides the footprint per person
-    by 2. But in reality, a study carried out in the Ile-de-France region
-    shows that the reductions are more like 20%... before the rebound
-    effects, which reduce the final gain of carpooling to only 6%.
+    One might naively think that carpooling divides the footprint per person by 2. But in reality, <a href="https://www.sciencedirect.com/science/article/pii/S1361920918303201">a study carried out in the Île-de-France region</a> shows that reductions are more in the order of 20%... before rebound effects, which reduce the final gain from carpooling to just 6%.
 
     ![](https://images.theconversation.com/files/297327/original/file-20191016-98644-c9y1zz.png?ixlib=rb-1.1.0&q=30&auto=format&w=754&h=588&fit=crop&dpr=2)
   description.auto: |
-    One might naively think that carpooling divides the footprint per person by 2. But in reality, a study carried out in the Ile-de-France region shows that the reductions are more like 20%... before the rebound effects, which reduce the final gain of carpooling to only 6%.
+    One might naively think that carpooling divides the footprint per person by 2. But in reality, <a href="https://www.sciencedirect.com/science/article/pii/S1361920918303201">a study carried out in the Île-de-France region</a> shows that reductions are more in the order of 20%... before rebound effects, which reduce the final gain from carpooling to just 6%.
 
     ![](https://images.theconversation.com/files/297327/original/file-20191016-98644-c9y1zz.png?ixlib=rb-1.1.0&q=30&auto=format&w=754&h=588&fit=crop&dpr=2)
   description.lock: |
-    On pourrait naïvement penser que le covoiturage divise par 2 l'empreinte par personne. Mais en réalité, une étude menée en Île-de-France montre que les réductions sont plutôt de l'ordre de 20%... avant les effets rebonds, qui réduisent le gain final du covoiturage à seulement 6%.
+    On pourrait naïvement penser que le covoiturage divise par 2 l'empreinte par personne. Mais en réalité, [une étude menée en Île-de-France](https://www.sciencedirect.com/science/article/pii/S1361920918303201) montre que les réductions sont plutôt de l'ordre de 20%... avant les effets rebonds, qui réduisent le gain final du covoiturage à seulement 6%.
 
     ![](https://images.theconversation.com/files/297327/original/file-20191016-98644-c9y1zz.png?ixlib=rb-1.1.0&q=30&auto=format&w=754&h=588&fit=crop&dpr=2)
   titre: carpooling discount
   titre.auto: carpooling discount
   titre.lock: réduction covoiturage
+  note: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car sharing be a sustainable mode of transport?</a>
+  note.auto: |
+    See The Conversation article <a href="https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122">Under what conditions will car sharing be a sustainable mode of transport?</a>
+  note.lock: |
+    Voir l'article The Conversation [À quelles conditions le covoiturage sera-t-il un mode de transport durable ?](https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122).
 transport . seuil d'activation 5km:
   description: |
     Minimum distance to trigger this action. 
@@ -19822,6 +20019,12 @@ transport . éco-conduite:
   titre: Adopt eco-driving
   titre.auto: Adopt eco-driving
   titre.lock: Adopter une éco-conduite
+  note: |
+    See the <a href="https://expertises.ademe.fr/air-mobilites/mobilite-transports/passer-a-laction/solutions-technologiques/dossier/optimiser-lutilisation-lentretien-vehicule/lecoconduite-attitude-a-adopter">ADEME-LaPoste eco-driving training guide</a>
+  note.auto: |
+    See the <a href="https://expertises.ademe.fr/air-mobilites/mobilite-transports/passer-a-laction/solutions-technologiques/dossier/optimiser-lutilisation-lentretien-vehicule/lecoconduite-attitude-a-adopter">ADEME-LaPoste eco-driving training guide</a>
+  note.lock: |
+    Voir le [Guide de formation à l'éco-conduite ADEME-LaPoste](https://expertises.ademe.fr/air-mobilites/mobilite-transports/passer-a-laction/solutions-technologiques/dossier/optimiser-lutilisation-lentretien-vehicule/lecoconduite-attitude-a-adopter)
 transport . éco-conduite . recalcul:
   note: A recalculation is necessary here, because the user may have used the input help tool which then prorates the km variable to the number of travelers. Otherwise it is not the case.
   note.auto: A recalculation is necessary here, because the user may have used the input help tool which then prorates the km variable to the number of travelers. Otherwise it is not the case.
@@ -19843,6 +20046,9 @@ transport . éco-conduite . usage réduit:
   titre: Direct emissions from households France
   titre.auto: Direct emissions from households France
   titre.lock: Emissions direct ménages France
+  note: Figure taken from <a href="https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021">the French Ministry of Ecology's estimate of France's national footprint</a>
+  note.auto: Figure taken from <a href="https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021">the French Ministry of Ecology's estimate of France's national footprint</a>
+  note.lock: Chiffre issu de [l'estimation de l'empreinte nationale française par le Ministère de l'Écologie](https://www.statistiques.developpement-durable.gouv.fr/lempreinte-carbone-de-la-france-de-1995-2021)
 émissions direct ménages par hab:
   description: Corresponds to direct household emissions (from fuels consumed by individual vehicles and fossil fuels used in housing boilers)
   description.auto: Corresponds to direct household emissions (from fuels consumed by individual vehicles and fossil fuels used in housing boilers)

--- a/data/logement/chauffage.publicodes
+++ b/data/logement/chauffage.publicodes
@@ -254,8 +254,8 @@ logement . chauffage . intensité carbone GPL:
   formule: 0.272
   unité: kgCO2e/kWh
   note: |
-    FE issu de le Base Carbone (GPL pour véhicule routier). 
-    Il n'y a pas de GPL de "maison" dans la Base Carbone. Une solution pourrait être de pointer directement sur le FE gaz naturel ?
+    Facteur d'émission issu de le Base Carbone (GPL pour véhicule routier). 
+    Il n'y a pas de GPL de "maison" dans la Base Carbone. Une solution pourrait être de pointer directement sur le facteur d'émission gaz naturel ?
 
 logement . chauffage . bouteille gaz:
   icônes: 🛢️🔥
@@ -329,7 +329,7 @@ logement . chauffage . bouteille gaz . empreinte contenu:
   titre: Empreinte gaz d'une bonbonne
   formule: (empreinte butane + empreinte propane) / 2
   unité: kgCO2e/kg
-  note: Moyenne entre butane et propane, dont les FE sont néanmoins très proches.
+  note: Moyenne entre butane et propane, dont les facteurs d'émission sont néanmoins très proches.
 
 logement . chauffage . empreinte butane:
   titre: Empreinte butane
@@ -440,7 +440,7 @@ logement . chauffage . fioul . consommation:
 logement . chauffage . intensité carbone fioul litre:
   formule: 3.25
   unité: kgCO2e/l
-  note: FE issu de la Base Carbone (Fioul domestique France continental).
+  note: Facteur d'émission issu de la Base Carbone (Fioul domestique France continental).
 
 logement . chauffage . bois:
   titre: Bois ou granulés
@@ -535,9 +535,9 @@ logement . chauffage . bois . facteur d'émission bûche:
   formule: 0.0460
   unité: kgCO2e/kWh
   note: |
-    Attention faute de FE de statut "validé générique" pour le bois bûche dans la Base Carbone nous optons pour un FE "validé spécifique" (initiative E+/C- = label Energie Positive et Réduction Carbone) afin d'assurer une
+    Attention faute de facteur d'émission de statut "validé générique" pour le bois bûche dans la Base Carbone nous optons pour un facteur d'émission "validé spécifique" (initiative E+/C- = label Energie Positive et Réduction Carbone) afin d'assurer une
     certaine cohérence pour l'utilisateur parcourant le modèle de calcul. Cependant, les facteurs d'émissions E+/C- suivent des règles d'élaboration parfois différentes des
-    règles de calcul de la Base Carbone. Il est donc probable que ce FE sous-estime légèrement l'impact GES de la consommation d'un kWh de bois bûche en ne prenant pas en 
+    règles de calcul de la Base Carbone. Il est donc probable que ce facteur d'émission sous-estime légèrement l'impact GES de la consommation d'un kWh de bois bûche en ne prenant pas en 
     compte les émissions de méthane imbrulé.
 
 logement . chauffage . bois . facteur d'émission granulés:
@@ -545,7 +545,7 @@ logement . chauffage . bois . facteur d'émission granulés:
   formule: 0.0113
   unité: kgCO2e/kWh
   note: |
-    FE de la Base Carbone Granulés/Blancs français (issus de connexe de scierie)
+    Facteur d'émission de la Base Carbone Granulés/Blancs français (issus de connexe de scierie)
     Connexe de scierie signifie que les granulés sont issus de chutes de bois et non de bois brut
 
 logement . chauffage . réseau de chaleur:
@@ -607,4 +607,4 @@ logement . chauffage . réseau de chaleur . intensité carbone:
   titre: Empreinte carbone réseau de chaleur
   formule: 0.125
   unité: kgCO2e/kWh
-  note: FE issu de la moyenne de tous les réseaux de chaleur de la Base Carbone
+  note: Facteur d'émission issu de la moyenne de tous les réseaux de chaleur de la Base Carbone

--- a/data/logement/chauffage.publicodes
+++ b/data/logement/chauffage.publicodes
@@ -166,8 +166,6 @@ logement . chauffage . gaz . intensité carbone gaz utilisateur:
       - si: chauffage . gaz . biogaz
         alors: biogaz . facteur d'émission
       - sinon: facteur d'émission base carbone
-  références:
-    - https://bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Gaz
   unité: kgCO2e/kWh
 
 logement . chauffage . gaz . facteur d'émission base carbone:
@@ -255,9 +253,9 @@ logement . chauffage . biogaz . part:
 logement . chauffage . intensité carbone GPL:
   formule: 0.272
   unité: kgCO2e/kWh
-  référence:
-    - https://www.bilans-ges.ademe.fr - GPL pour véhicule routier
-  #Il n'y a pas de GPL de "maison" dans la Base Carbone. Pointer directement sur le FE gaz naturel ?
+  note: |
+    FE issu de le Base Carbone (GPL pour véhicule routier). 
+    Il n'y a pas de GPL de "maison" dans la Base Carbone. Une solution pourrait être de pointer directement sur le FE gaz naturel ?
 
 logement . chauffage . bouteille gaz:
   icônes: 🛢️🔥
@@ -423,14 +421,12 @@ logement . chauffage . fioul . estimation via le prix:
   question: Pas de facture ? Entrez vos dépenses approximatives en fioul par mois
   unité: €/l
   formule: 1.5199
-  description: |
+  note: |
     Cette formule nous permet de passer des €/mois aux litres/an.
 
     Source : Fioul domestique 2000 à 4999 litres, 2ème semestre 2022.
     Donnée issue de l'excel [Prix HTT et TTC depuis janvier 2020.xlsx](https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx)
     téléchargeable sur la page [Prix des produits pétroliers](https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4) du ministère de la Transition Écologique.
-  références:
-    écologie.gouv.fr: https://www.ecologie.gouv.fr/prix-des-produits-petroliers
 
 logement . chauffage . fioul . consommation:
   question: Quelle est la consommation annuelle de fioul domestique de votre foyer ?
@@ -444,8 +440,7 @@ logement . chauffage . fioul . consommation:
 logement . chauffage . intensité carbone fioul litre:
   formule: 3.25
   unité: kgCO2e/l
-  références:
-    - https://www.bilans-ges.ademe.fr - Fioul domestique France continental
+  note: FE issu de la Base Carbone (Fioul domestique France continental).
 
 logement . chauffage . bois:
   titre: Bois ou granulés
@@ -475,8 +470,6 @@ logement . chauffage . bois . présent:
 logement . chauffage . bois . type:
   titre: type de bois
   question: Quel type de bois utilisez-vous ?
-  description: |
-    > Les poêles à bûches représentent 70% des poêles vendus.
   formule:
     une possibilité:
       choix obligatoire: oui
@@ -484,8 +477,7 @@ logement . chauffage . bois . type:
         - bûche
         - granulés
   par défaut: "'bûche'"
-  références:
-    planetoscope: https://www.planetoscope.com/Source-d-energie/1521-.html
+  note: Les poêles à bûches représentent [70% des poêles vendus](https://www.planetoscope.com/Source-d-energie/1521-.html).
 
 logement . chauffage . bois . type . bûche:
   titre: Bûches
@@ -517,11 +509,7 @@ logement . chauffage . bois . type . bûche . consommation:
 logement . chauffage . bois . type . bûche . intensité énergétique:
   formule: 1610
   unité: kWh/stère
-  note: |
-    Nous faisons l'hypothèse d'une consommation de bûches de 20% d'humidité.
-    Source : dans le fichier ZIP (!) ci-dessous, fichier 1_chauffage_domestique_bois_appro_rapport.pdf page 10.
-  références:
-    - https://www.ademe.fr/etude-chauffage-domestique-bois
+  note: Nous faisons l'hypothèse d'une consommation de bûches de 20% d'humidité, d'après l'[étude ADEME sur le chauffahe domestique au bois](https://librairie.ademe.fr/produire-autrement/872-etude-sur-le-chauffage-domestique-au-bois.html), page 10.
 
 logement . chauffage . bois . type . bûche . consommation . saisie:
   question: Quelle la consommation annuelle de bois en bûches de votre foyer ?

--- a/data/logement/chiffres parc logements français.publicodes
+++ b/data/logement/chiffres parc logements français.publicodes
@@ -5,9 +5,7 @@ parc français:
     La difficulté en effet, c'est que certains foyers se chauffent au gaz (~40%), à l'électricité (~40%), au fioul, au bois, etc. 
 
     Nous attribuons donc comme moyenne d'empreinte climat l'empreinte des kWh de ces énergies pondérées par leur usage réel dans le parc français.
-
-  références:
-    - https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel
+  note: Ce modèle est basé sur le jeu de données du Ceren et SDES [Consommation d'énergie par usage du résidentiel](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel).
 
 parc français . surface moyenne:
   titre: Surface moyenne par logement

--- a/data/logement/climatisation.publicodes
+++ b/data/logement/climatisation.publicodes
@@ -2,7 +2,6 @@ logement . climatisation:
   icônes: ❄️
   titre: Empreinte de la climatisation
   formule: empreinte climatiseurs / habitants
-  unité: kgCO2e
   description: |
     Nous estimons ici l'empreinte de la climatisation. 
     Son empreinte est quadruple :   
@@ -32,7 +31,8 @@ logement . climatisation . présent:
     La climatisation utilise de l'électricité, que vous devez saisir en kWh ou en € dans la question électricité. L'empreinte de l'électricité consommée par le climatiseur est donc déjà calculée. 
 
     Mais en plus de cela, un climatiseur rejette d'autres gaz à effet de serre : d'où la nécessité de poser cette question.
-  par défaut: oui # valeur par défaut à oui pour l'intégrer dans l'empreinte moyenne
+  # Valeur par défaut à oui pour l'intégrer dans l'empreinte moyenne
+  par défaut: oui
 
 logement . climatisation . rappel kWh:
   type: notification

--- a/data/logement/construction.publicodes
+++ b/data/logement/construction.publicodes
@@ -29,30 +29,31 @@ logement . construction . par surface:
       - sinon: 425
   unité: kgCO2e/m2
   note: |
+    L'entrée dans la base carbone ne donne pas plus d'informations sur cette catégorie de méthode de construction. Voir la [documentation de la base empreinte, onglet Achats de bien/ Bâtiments](https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/).
+
+    Le facteur d'émission titre "Maison éco-construite", faute d'informations nous considérons qu'il est le même pour un appartement éco-construit.
+
+    Cependant, [cette étude de Carbone 4](https://www.carbone4.com/sauver-le-climat-avec-nos-forets-la-construction-touche-du-bois-2) affirme un réduction de 55% du béton au bois pour la maison, et de 60% pour l'appartement.
+
     Notons que pour le logement éco-construit, le CO₂ biogénique stocké n'est pas comptabilisé, seul le CO₂ fossile émis l'est.
 
     Pour le logement éco-construit, nous retenons le facteur d'émission de la base carbone, mais il semble confirmé en ordre de grandeur dans l'étude Carbone 4.
 
-    > Gains observés sur le CO₂ fossile du poste gros-œuvre (fondations et structure), en comparaison au béton. Le stockage de carbone dans le produit  bois  n’est  pas  pris  en  compte.  Gains  liés  à  la  substitution  matériau  :  MI  bois  CLT  :  118  kgCO2e/m2  SHON,  soit  473  kgCO2e/m3  de produit bois. MI bois ossature : 83 kgCO2e/m2 SHON, soit 2495 kgCO2e/m3 de produit bois. LC bois CLT : 231 kgCO2e/m2 SHON, soit 699 kgCO2e/m3 de produit bois. LC bois ossature : 139 kgCO2e/m2 SHON, soit 3172 kgCO2e/m3 de produit bois.
-  références:
-    éco-construit: https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Maison+éco-construite+«+bois
-    appartement et maison: https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Batiments
-    Carbone 4: http://www.carbone4.com/wp-content/uploads/2015/05/Note-de-communication-filière-bois-vf.pdf
+    > Gains observés sur le CO₂ fossile du poste gros-œuvre (fondations et structure), en comparaison au béton. 
+
+    Le stockage de carbone dans le produit bois n’est pas pris en compte.
+
+    Gains liés à la substitution matériau: 
+     - MI bois CLT: 118 kgCO2e/m2 SHON, soit 473 kgCO2e/m3 de produit bois. 
+     - MI bois ossature : 83 kgCO2e/m2 SHON, soit 2495 kgCO2e/m3 de produit bois. 
+     - LC bois CLT : 231 kgCO2e/m2 SHON, soit 699 kgCO2e/m3 de produit bois.
+     - LC bois ossature : 139 kgCO2e/m2 SHON, soit 3172 kgCO2e/m3 de produit bois.
 
 logement . éco-construit:
   question: Votre logement est-il fait en bois, paille, pierre ou terre (éco-construit) ?
   par défaut: non
-  notes: |
-    L'entrée dans la base carbone ne donne pas plus d'informations sur cette catégorie de méthode de construction.
-
-    Le facteur d'émission titre "Maison éco-construite", faute d'informations nous considérons qu'il est le même pour un appartement éco-construit. Cependant, l'étude Carbone 4 l'affirme (réduction de 55% du béton au bois pour la maison, et de 60% pour l'appartement).
-  références:
-    Base carbone: https://www.bilans-ges.ademe.fr/fr/basecarbone/donnees-consulter/liste-element?recherche=Maison+éco-construite+«+bois
-    Carbone 4: http://www.carbone4.com/wp-content/uploads/2015/05/Note-de-communication-filière-bois-vf.pdf
 
 logement . construction . durée d'amortissement:
   formule: 50
   note: |
-    Ces valeurs tiennent compte de l’entretien et de l’éventuel remplacement des produits et équipements durant la vie du bâtiment fixée à 50 ans.
-  références:
-    base carbone: https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?batiments.htm
+    La durée de vie d'un bâtiment est fixée à 50 ans (voir la [documentation de la base empreinte, onglet Achats de bien/ Bâtiments](https://prod-basecarbonesolo.ademe-dri.fr/documentation/UPLOAD_DOC_FR/)).

--- a/data/logement/logement.publicodes
+++ b/data/logement/logement.publicodes
@@ -97,21 +97,17 @@ logement . appartement:
 
     > Si vous vivez dans un habitat original, par exemple un camping-car / un camion / une péniche, pas de problème : choisissez "appartement" et saisissez les m² de ce qui constitue quand même votre logement.
   note: |
-    > En 2018, l’habitat individuel représente 56 % des logements : il est majoritaire parmi les résidences principales comme parmi les résidences secondaires et logements occasionnels. Après avoir progressé entre 1999 et 2008 sa part recule légèrement, car le nombre de logements collectifs augmente plus vite que celui des logements individuels du fait des évolutions récentes de la construction neuve.
+    En 2018, l’habitat individuel représente 56 % des logements ([Source INSEE](https://www.insee.fr/fr/statistiques/3676693?sommaire=3696937)) : il est majoritaire parmi les résidences principales comme parmi les résidences secondaires et logements occasionnels. Après avoir progressé entre 1999 et 2008 sa part recule légèrement, car le nombre de logements collectifs augmente plus vite que celui des logements individuels du fait des évolutions récentes de la construction neuve.
     Notons qu'il s'agit d'une proportion de logements ; or on peut s'attendre (à vérifier) à ce que les maisons contiennent davantage de gens en moyenne que les appartements, ce qui renforce le choix de la valeur par défaut.
-  références:
-    INSEE: https://www.insee.fr/fr/statistiques/3676693?sommaire=3696937
 
 logement . âge:
   question: Quel est l'âge de votre logement ?
   par défaut: 45
   unité: an
   description: |
-    En France, 24% du parc de logements date d'avant 1949 et 24% entre 1949 et 1974.
+    En France, 24% du parc de logements date d'avant 1949 et 24% entre 1949 et 1974 selon l'[INSEE](https://www.insee.fr/fr/statistiques/fichier/2586377/LOGFRA17.pdf).
 
     Pour Paris, [cette carte](https://www.comeetie.fr/galerie/BatiParis) interactive est fascinante si la question de l'âge de ses logements vous intéresse.
-  références:
-    INSEE: 24% du parc de logements date d'avant 1949 et 24% entre 1949 et 1974 par exemple (https://www.insee.fr/fr/statistiques/fichier/2586377/LOGFRA17.pdf).
   suggestions:
     neuf: 0
     récent: 10

--- a/data/logement/prix du gaz.publicodes
+++ b/data/logement/prix du gaz.publicodes
@@ -12,7 +12,8 @@ gaz:
     Nous partons donc du principe que le tarif reglementé reste représentatif du prix d'un foyer moyen. 
 
     Source pour [la liste des taxes](https://www.energie-info.fr/fiche_pratique/cspe-ticgn-cta-tva-toutes-les-taxes-sur-ma-facture/).
-  références: https://tarifgaz.com/tarifs
+
+    Voir également: https://tarifgaz.com/tarifs
 
 gaz . marginal HT:
   formule: 0.0785

--- a/data/logement/électricité.publicodes
+++ b/data/logement/électricité.publicodes
@@ -33,8 +33,8 @@ logement . électricité . estimation via le coût:
     Cette formule nous permet de passer des €/mois aux kWh/an.
 
     Le chiffre inclut un coût de l'abonnement, et représente donc une moyenne. Ce n'est pas le prix du kWh marginal. Il inclut les taxes.
-  références:
-    Eurostat household second half 2021: https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics
+
+    Chiffre issu de [Eurostat, household, second half 2021](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics).
 
 logement . électricité . intensité carbone:
   formule: commun . intensité électricité

--- a/data/transport/bus.publicodes
+++ b/data/transport/bus.publicodes
@@ -22,9 +22,7 @@ transport . bus . impact par km:
 transport . bus . vitesse:
   formule: 12
   unité: km/h
-  note: Hypothèse de 12 km/h de vitesse moyenne, Mairie de Paris, consulté le 05/09/2014
-  références:
-    - http://www.paris.fr/pratique/deplacements-voirie/transports-en-commun/promouvoir-les-transports-collectifs/rub_385_stand_10755_port_1208
+  note: Hypothèse de 12 km/h de vitesse moyenne.
 
 transport . bus . heures par semaine:
   question: Combien d'heures passez-vous dans un bus par semaine ?

--- a/data/transport/métro ou tram.publicodes
+++ b/data/transport/métro ou tram.publicodes
@@ -20,9 +20,7 @@ transport . métro ou tram . impact par km:
 transport . métro ou tram . vitesse:
   formule: 25
   unité: km/h
-  note: Hypothèse de 25 km/h de vitesse moyenne, transports.blog.lemonde.fr, consulté le 05/09/2014
-  références:
-    - http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/
+  note: Hypothèse de 25 km/h de vitesse moyenne, d'après l'article [Les petits secrets de la RATP révélés au public](http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/)
 
 transport . métro ou tram . heures par semaine:
   question: Combien d'heures passez-vous par semaine en métro ou en tram ?


### PR DESCRIPTION
Fix #2077 

Migration de tous les liens de `références` dans les notes

On avait également des erreurs via l'ajout de liens dans `reference` ou `références` qui ne sont pas des mécanismes publicodes.