### PR TITLE
`description` -> `note` dans les aides à la saisie

### DIFF
--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -15572,17 +15572,17 @@ logement . chauffage . bois . type . bûche . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . bois . type . bûche . consommation . estimation via le coût:
-  description: |
-    This formula allows us to go from €/month to the number of steres per year.
-  description.auto: |
-    This formula allows us to go from €/month to the number of steres per year.
-  description.lock: |
-    Cette formule nous permet de passer des €/mois au nombre de stères par an.
   note: |
+    This formula allows us to switch from €/month to number of steres per year.
+
     Price calculated on the basis of the wood energy price index published by INSEE.
   note.auto: |
+    This formula allows us to switch from €/month to number of steres per year.
+
     Price calculated on the basis of the wood energy price index published by INSEE.
   note.lock: |
+    Cette formule nous permet de passer des €/mois au nombre de stères par an.
+
     Prix calculé sur la base de l'indice prix bois énergie publié par l'INSEE.
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
@@ -15656,18 +15656,18 @@ logement . chauffage . bois . type . granulés . consommation:
 
     Et donc probablement que si la discrimination par type de bois de chauffe était faite dans les données du CEREN (pour les kWh consommés et les surface chauffées) on aboutirait à une valeur en kWh/m2 beaucoup plus faible pour les granulés que pour le bois bûches.
 logement . chauffage . bois . type . granulés . consommation . estimation via le coût:
-  description: |
-    This formula allows us to go from €/month to kWh/year: the kWh cost x cents per month over 12 months.
-  description.auto: |
-    This formula allows us to go from €/month to kWh/year: the kWh cost x cents per month over 12 months.
-  description.lock: |
-    Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
   question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
   titre: estimation via cost
   titre.auto: estimation via cost
   titre.lock: estimation via le coût
+  note: |
+    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+  note.auto: |
+    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+  note.lock: |
+    Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
 logement . chauffage . bouteille gaz:
   titre: Gas bottle
   titre.auto: Gas bottle
@@ -15743,20 +15743,23 @@ logement . chauffage . bouteille gaz . empreinte contenu:
   titre.auto: Gas footprint of a cylinder
   titre.lock: Empreinte gaz d'une bonbonne
 logement . chauffage . bouteille gaz . estimation via le poids:
-  description: This aid simplifies the conversion of kg of gas consumed into a 13kg gas cylinder.
-  description.auto: This aid simplifies the conversion of kg of gas consumed into a 13kg gas cylinder.
-  description.lock: Cette aide permet de simplifier la conversion des kg de gaz consommés en bouteille de gaz au format 13kg.
   note: |
-    This estimation aid is designed to receive monthly consumption as input (see InputEstimation.tsx on the site side).
-    However, in this particular case, we'd like to offer estimation help for the whole year, and expect consumption to be per year rather than per month (a period that corresponds more closely to supplier invoices) 
+    This aid simplifies the conversion of kg of gas consumed into 13kg gas cylinders.
+
+    This estimation help mechanism is designed to receive monthly consumption as input (see InputEstimation.tsx on the site side).
+    However, in this particular case, we'd like to offer an estimation aid for the whole year, and expect consumption to be per year 
     and not by month (a period that corresponds more closely to supplier invoices).
     For this reason, the formula includes a factor of 12.
   note.auto: |
-    This estimation aid is designed to receive monthly consumption as input (see InputEstimation.tsx on the site side).
-    However, in this particular case, we'd like to offer estimation help for the whole year, and expect consumption to be per year rather than per month (a period that corresponds more closely to supplier invoices) 
+    This aid simplifies the conversion of kg of gas consumed into 13kg gas cylinders.
+
+    This estimation help mechanism is designed to receive monthly consumption as input (see InputEstimation.tsx on the site side).
+    However, in this particular case, we'd like to offer an estimation aid for the whole year, and expect consumption to be per year 
     and not by month (a period that corresponds more closely to supplier invoices).
     For this reason, the formula includes a factor of 12.
   note.lock: |
+    Cette aide permet de simplifier la conversion des kg de gaz consommés en bouteille de gaz au format 13kg.
+
     Ce mécanisme d'aide à l'estimation est conçu pour recevoir une consommation mensuelle en entrée (cf InputEstimation.tsx côté site).
     Néanmoins, pour ce cas précis, nous souhaitons proposer une aide à l'estimation sur l'année et attendons une consommation par an 
     et non par mois (période correspondant davantage aux factures de fournisseurs).
@@ -15805,18 +15808,21 @@ logement . chauffage . citerne propane . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . citerne propane . estimation via le coût:
-  description: |
+  note: |
     According to information aggregated by <a href="https://www.hellowatt.fr/gaz-propane-citerne/comparatif-prix">HelloWatt</a>, 
     the price of propane in a tank fluctuates around €1,800 per tonne (depending on the supplier).
-  description.auto: |
+
+    This estimation aid is designed to receive a monthly consumption (see InputEstimation.tsx on the website)
+  note.auto: |
     According to information aggregated by <a href="https://www.hellowatt.fr/gaz-propane-citerne/comparatif-prix">HelloWatt</a>, 
     the price of propane in a tank fluctuates around €1,800 per tonne (depending on the supplier).
-  description.lock: |
+
+    This estimation aid is designed to receive a monthly consumption (see InputEstimation.tsx on the website)
+  note.lock: |
     Selon les informations agrégées par le site [HelloWatt](https://www.hellowatt.fr/gaz-propane-citerne/comparatif-prix), 
     le prix du propane en citerne oscille autour de 1800€ par tonne (selon le fournisseur).
-  note: This estimation aid is designed to receive monthly consumption (see InputEstimation.tsx on the site side)
-  note.auto: This estimation aid is designed to receive monthly consumption (see InputEstimation.tsx on the site side)
-  note.lock: Cette aide à l'estimation est désignée pour recevoir une consommation mensuelle (cf InputEstimation.tsx côté site)
+
+    Cette aide à l'estimation est désignée pour recevoir une consommation mensuelle (cf InputEstimation.tsx côté site)
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
   question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
@@ -15876,24 +15882,6 @@ logement . chauffage . fioul . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . fioul . estimation via le prix:
-  description: |
-    This formula allows us to switch from €/month to liters/year.
-
-    Source: Heating oil 2000 to 4999 liters, 2nd semester 2022.
-    Data taken from excel <a href="https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx">Prices ex VAT and inc VAT since January 2020.xlsx</a>
-    downloadable from the French Ministry of Ecological Transition's <a href="https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4">Petroleum Product Prices</a> page.
-  description.auto: |
-    This formula allows us to switch from €/month to liters/year.
-
-    Source: Heating oil 2000 to 4999 liters, 2nd semester 2022.
-    Data taken from excel <a href="https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx">Prices ex VAT and inc VAT since January 2020.xlsx</a>
-    downloadable from the French Ministry of Ecological Transition's <a href="https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4">Petroleum Product Prices</a> page.
-  description.lock: |
-    Cette formule nous permet de passer des €/mois aux litres/an.
-
-    Source : Fioul domestique 2000 à 4999 litres, 2ème semestre 2022.
-    Donnée issue de l'excel [Prix HTT et TTC depuis janvier 2020.xlsx](https://github.com/datagir/nosgestesclimat/files/11029116/Prix.HTT.et.TTC.depuis.janvier.2020.xlsx)
-    téléchargeable sur la page [Prix des produits pétroliers](https://www.ecologie.gouv.fr/prix-des-produits-petroliers#scroll-nav__4) du ministère de la Transition Écologique.
   question: No bill? Enter your approximate monthly fuel costs
   question.auto: No bill? Enter your approximate monthly fuel costs
   question.lock: Pas de facture ? Entrez vos dépenses approximatives en fioul par mois
@@ -15993,33 +15981,30 @@ logement . chauffage . gaz . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . gaz . estimation via le coût:
-  description: |
-    This formula allows us to go from €/month to kWh/year : the kWh cost x
-    cents per month over 12 months.
-
-    See the tab "Energy consumption calculation" of the [MicMac
-    spreadsheet](https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx).
-    Updated via a small calculation algorithm in January 2022, following the
-    historical price increases in 2021. The value for 2022 is approximately
-    0.104 €/kWh.
-  description.auto: |
-    This formula allows us to go from €/month to kWh/year: the kWh cost x cents per month over 12 months.
-
-    See the tab "Energy consumption calculation" of the <a href="https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx">MicMac spreadsheet</a>
-    Updated via a small calculation algorithm in January 2022, following the historical price increases in 2021.
-    The value for 2022 is approximately 0.104 €/kWh.
-  description.lock: |
-    Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
-
-    Voir l'onglet "Calcul consommation Energie" du [tableur MicMac](https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx)
-    Mis à jour via un petit algorithme de calcul en janvier 2022, suite aux hausses historiques du prix en 2021.
-    La valeur pour 2022 est approximativement de 0.104 €/kWh.
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
   question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
   titre: estimation via cost
   titre.auto: estimation via cost
   titre.lock: estimation via le coût
+  note: |
+    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+
+    See the "Energy consumption calculation" tab in the <a href="https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx">MicMac spreadsheet</a>
+    Updated via a small calculation algorithm in January 2022, following historic price rises in 2021.
+    The value for 2022 is approximately 0.104 €/kWh.
+  note.auto: |
+    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+
+    See the "Energy consumption calculation" tab in the <a href="https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx">MicMac spreadsheet</a>
+    Updated via a small calculation algorithm in January 2022, following historic price rises in 2021.
+    The value for 2022 is approximately 0.104 €/kWh.
+  note.lock: |
+    Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
+
+    Voir l'onglet "Calcul consommation Energie" du [tableur MicMac](https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx)
+    Mis à jour via un petit algorithme de calcul en janvier 2022, suite aux hausses historiques du prix en 2021.
+    La valeur pour 2022 est approximativement de 0.104 €/kWh.
 logement . chauffage . gaz . présent:
   note: |
     Although the majority of heating in France is electric [source](https://fr.statista.com/statistiques/856283/types-chauffage-logement-principal-france), we set the default value here to yes to be closer to the average footprint of the dwelling.
@@ -16113,8 +16098,14 @@ logement . chauffage . réseau de chaleur . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . réseau de chaleur . estimation via le prix:
-  description: |
-    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+  question: No invoice? Enter your approximate monthly expenses
+  question.auto: No invoice? Enter your approximate monthly expenses
+  question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
+  titre: estimation via price
+  titre.auto: estimation via price
+  titre.lock: estimation via le prix
+  note: |
+    This formula allows us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
 
     This figure is taken from the<a href="https://amorce.asso.fr/actualite/les-reseaux-de-chaleur-la-bonne-solution-de-chauffage-pour-le-pouvoir-d-achat-et-le-climat">Heating and Cooling Network</a> Survey 
     based on 2021 data, which gives a figure of 80€HT/MWh.
@@ -16128,8 +16119,8 @@ logement . chauffage . réseau de chaleur . estimation via le prix:
 
     This is an average value with a relatively large standard deviation.
     Nevertheless, the survey states that "average sales prices for heating networks vary widely, with 89% of heat delivered sold at a price between -30% and +30% of the national average".
-  description.auto: |
-    This formula enables us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
+  note.auto: |
+    This formula allows us to switch from €/month to kWh/year: kWh costs x cents per month over 12 months.
 
     This figure is taken from the<a href="https://amorce.asso.fr/actualite/les-reseaux-de-chaleur-la-bonne-solution-de-chauffage-pour-le-pouvoir-d-achat-et-le-climat">Heating and Cooling Network</a> Survey 
     based on 2021 data, which gives a figure of 80€HT/MWh.
@@ -16143,7 +16134,7 @@ logement . chauffage . réseau de chaleur . estimation via le prix:
 
     This is an average value with a relatively large standard deviation.
     Nevertheless, the survey states that "average sales prices for heating networks vary widely, with 89% of heat delivered sold at a price between -30% and +30% of the national average".
-  description.lock: |
+  note.lock: |
     Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
 
     Ce chiffre est tiré de l'[Enquête des réseaux de chaleur et de froid](https://amorce.asso.fr/actualite/les-reseaux-de-chaleur-la-bonne-solution-de-chauffage-pour-le-pouvoir-d-achat-et-le-climat) 
@@ -16158,12 +16149,6 @@ logement . chauffage . réseau de chaleur . estimation via le prix:
 
     C'est une valeur moyenne dont l'écart-type est relativement important.
     Néanmoins, on peut lire dans l'enquête que "les prix de vente moyens des réseaux de chaleur affichent une très grande disparité, 89% de la chaleur livrée est vendue à un prix compris entre -30 et +30% de la moyenne nationale".
-  question: No invoice? Enter your approximate monthly expenses
-  question.auto: No invoice? Enter your approximate monthly expenses
-  question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
-  titre: estimation via price
-  titre.auto: estimation via price
-  titre.lock: estimation via le prix
 logement . chauffage . réseau de chaleur . présent:
   question: Is your home heated by a heating network?
   question.auto: Is your home heated by a heating network?
@@ -17123,30 +17108,30 @@ logement . électricité . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . électricité . estimation via le coût:
-  description: |
-    This formula enables us to switch from €/month to kWh/year.
-
-    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
-
-    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
-  description.auto: |
-    This formula enables us to switch from €/month to kWh/year.
-
-    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
-
-    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
-  description.lock: |
-    Cette formule nous permet de passer des €/mois aux kWh/an.
-
-    Le chiffre inclut un coût de l'abonnement, et représente donc une moyenne. Ce n'est pas le prix du kWh marginal. Il inclut les taxes.
-
-    Chiffre issu de [Eurostat, household, second half 2021](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics).
   question: No invoice? Enter your approximate monthly expenses
   question.auto: No invoice? Enter your approximate monthly expenses
   question.lock: Pas de facture ? Entrez vos dépenses approximatives par mois
   titre: estimation via cost
   titre.auto: estimation via cost
   titre.lock: estimation via le coût
+  note: |
+    This formula enables us to switch from €/month to kWh/year.
+
+    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
+
+    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
+  note.auto: |
+    This formula enables us to switch from €/month to kWh/year.
+
+    The figure includes a subscription cost, and therefore represents an average. It is not the marginal price per kWh. It includes taxes.
+
+    Figure taken from <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics">Eurostat, household, second half 2021</a>.
+  note.lock: |
+    Cette formule nous permet de passer des €/mois aux kWh/an.
+
+    Le chiffre inclut un coût de l'abonnement, et représente donc une moyenne. Ce n'est pas le prix du kWh marginal. Il inclut les taxes.
+
+    Chiffre issu de [Eurostat, household, second half 2021](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics).
 logement . électricité . intensité carbone:
   description: |
     Here we use the average footprint of the mix in the simulation region.

--- a/data/logement/chauffage.publicodes
+++ b/data/logement/chauffage.publicodes
@@ -123,7 +123,7 @@ logement . chauffage . gaz . estimation via le coût:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/kWh
   formule: gaz . prix
-  description: |
+  note: |
     Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
 
     Voir l'onglet "Calcul consommation Energie" du [tableur MicMac](https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx)
@@ -303,11 +303,12 @@ logement . chauffage . bouteille gaz . estimation via le poids:
   unité: kg/bouteille
   formule: 13 * 12
   note: |
+    Cette aide permet de simplifier la conversion des kg de gaz consommés en bouteille de gaz au format 13kg.
+
     Ce mécanisme d'aide à l'estimation est conçu pour recevoir une consommation mensuelle en entrée (cf InputEstimation.tsx côté site).
     Néanmoins, pour ce cas précis, nous souhaitons proposer une aide à l'estimation sur l'année et attendons une consommation par an 
     et non par mois (période correspondant davantage aux factures de fournisseurs).
     C'est pourquoi , la formule présente un facteur 12.
-  description: Cette aide permet de simplifier la conversion des kg de gaz consommés en bouteille de gaz au format 13kg.
 
 logement . chauffage . bouteille gaz . énergie par bouteille:
   titre: Energie bouteille de gaz (13 kg)
@@ -376,10 +377,11 @@ logement . chauffage . citerne propane . estimation via le coût:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/kg
   formule: 1.8
-  note: Cette aide à l'estimation est désignée pour recevoir une consommation mensuelle (cf InputEstimation.tsx côté site)
-  description: |
+  note: |
     Selon les informations agrégées par le site [HelloWatt](https://www.hellowatt.fr/gaz-propane-citerne/comparatif-prix), 
     le prix du propane en citerne oscille autour de 1800€ par tonne (selon le fournisseur).
+
+    Cette aide à l'estimation est désignée pour recevoir une consommation mensuelle (cf InputEstimation.tsx côté site)
 
 logement . chauffage . citerne propane . énergie par kg:
   formule: 46 MJ/kg * 1.111 / 3.6 MJ/kWh
@@ -501,7 +503,7 @@ logement . chauffage . bois . type . granulés . consommation . estimation via l
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/kWh
   formule: granulés . prix kWh
-  description: |
+  note: |
     Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
 
 logement . chauffage . bois . type . bûche . consommation:
@@ -525,9 +527,9 @@ logement . chauffage . bois . type . bûche . consommation . estimation via le c
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/stère
   formule: prix stère 2023
-  description: |
-    Cette formule nous permet de passer des €/mois au nombre de stères par an.
   note: |
+    Cette formule nous permet de passer des €/mois au nombre de stères par an.
+
     Prix calculé sur la base de l'indice prix bois énergie publié par l'INSEE.
 
 logement . chauffage . bois . facteur d'émission bûche:
@@ -572,7 +574,7 @@ logement . chauffage . réseau de chaleur . estimation via le prix:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/kWh
   formule: 0.085
-  description: |
+  note: |
     Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois.
 
     Ce chiffre est tiré de l'[Enquête des réseaux de chaleur et de froid](https://amorce.asso.fr/actualite/les-reseaux-de-chaleur-la-bonne-solution-de-chauffage-pour-le-pouvoir-d-achat-et-le-climat) 

--- a/data/logement/électricité.publicodes
+++ b/data/logement/électricité.publicodes
@@ -29,7 +29,7 @@ logement . électricité . estimation via le coût:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois
   unité: €/kWh
   formule: 0.2022
-  description: |
+  note: |
     Cette formule nous permet de passer des €/mois aux kWh/an.
 
     Le chiffre inclut un coût de l'abonnement, et représente donc une moyenne. Ce n'est pas le prix du kWh marginal. Il inclut les taxes.


### PR DESCRIPTION
Toujours dans l'idée d'harmoniser le comportement des notes et descriptions