### PR TITLE
Gestion du % dans la question biogaz (NGC-156)

### DIFF
--- a/data/logement/chauffage.publicodes
+++ b/data/logement/chauffage.publicodes
@@ -249,6 +249,7 @@ logement . chauffage . biogaz . part:
 
     Par contre, le premier vendeur de gaz français propose à ses clients une option biogaz avec une proportion reglable moyennant un coût supplémentaire (significatif mais qui ne fait pas non plus doubler la facture). N'hésitez pas à en parler à un conseiller.
   par défaut: 20%
+  unité: '%'
 
 logement . chauffage . intensité carbone GPL:
   formule: 0.272

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -333,7 +333,8 @@ personas . corentin:
     logement . chauffage . citerne propane . présent: non
     logement . chauffage . électricité . présent: non
     logement . chauffage . gaz . présent: oui
-    logement . chauffage . gaz . biogaz: non
+    logement . chauffage . gaz . biogaz: oui
+    logement . chauffage . biogaz . part: 30
     logement . chauffage . gaz . consommation: 3243
     logement . électricité . consommation: 800
     logement . éco-construit: non


### PR DESCRIPTION
Fix #2128
Fix #2129 

- [x] Ajout du biogaz pour corentin
- [x] Ajout de l'unité `%` géré par publicodes et qui n'était pas indiquée ici

Un bon exemple de cas non couvert que les tests de personas auraient permis de détecter ;)

Ici avant l'ajout du %:

<img width="675" alt="image" src="https://github.com/incubateur-ademe/nosgestesclimat/assets/55186402/5d87e032-fd24-49fc-8d4f-e6380df7b20d">
