### PR TITLE
Ajoute le RER dans le calcul `métro ou tram` (NGC-312)

### DIFF
--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -18583,18 +18583,24 @@ transport . km autoroute:
     Fil twitter intéressant sur le sujet: https://twitter.com/Tomsawy22670318/status/1274257124701462528.
 transport . métro ou tram:
   description: |
+    This covers all modes of urban rail transport.
+
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
   description.auto: |
+    This covers all modes of urban rail transport.
+
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
   description.lock: |
+    Il est question ici de tous les modes de transport urbains sur rails.
+
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
-  titre: Subway or tramway
-  titre.auto: Subway or tramway
-  titre.lock: Métro ou tramway
+  titre: Metro, tram, RER
+  titre.auto: Metro, tram, RER
+  titre.lock: Métro, tramway, RER
 transport . métro ou tram . heures par semaine:
-  question: How many hours a week do you spend on the metro or tram ?
-  question.auto: How many hours a week do you spend on the metro or streetcar?
-  question.lock: Combien d'heures passez-vous par semaine en métro ou en tram ?
+  question: How many hours a week do you spend on the metro, tram or RER?
+  question.auto: How many hours a week do you spend on the metro, tram or RER?
+  question.lock: Combien d'heures passez-vous par semaine en métro, tram, RER ?
   suggestions:
     - zero
     - 1h / day
@@ -18611,12 +18617,9 @@ transport . métro ou tram . heures par semaine:
   titre.auto: hours per week
   titre.lock: heures par semaine
 transport . métro ou tram . impact par heure:
-  description: |
-    Based on 6.63 gCO2e/(passenger.km) and an average speed of 25 km/h.
-  description.auto: |
-    Based on 6.63 gCO2e/(passenger.km) and an average speed of 25 km/h.
-  description.lock: |
-    Sur la base de 6,63 gCO2e/(passager.km) et de 25 km/h de vitesse moyenne.
+  description: We are confusing all means of urban rail transport, i.e. metro, tramway and RER.
+  description.auto: We are confusing all means of urban rail transport, i.e. metro, tramway and RER.
+  description.lock: Nous confondons l'ensemble des moyens de transport urbains sur rails, à savoir métro, tramway et RER.
   note: We have put in the same basket tramway and subway, while the MicMac v2.6 model only talks about subway.
   note.auto: We confused streetcar and subway, while the MicMac v2.6 model only talks about subway.
   note.lock: Nous avons confondu tram et métro, alors que le modèle MicMac v2.6 ne parle que de métro.
@@ -18624,9 +18627,9 @@ transport . métro ou tram . impact par heure:
   titre.auto: impact per hour
   titre.lock: impact par heure
 transport . métro ou tram . impact par km:
-  note: Metro, tramway, trolleybus - 2018 - Urban area &gt; 250 000 inhabitants; 3.29 gCO2e/km/person; Carbon base consulted on 04/04/2022
-  note.auto: Metro, tramway, trolleybus - 2018 - Urban area > 250 000 inhabitants; 3.29 gCO2e/km/person; Carbon base consulted on 04/04/2022
-  note.lock: Métro, tramway, trolleybus - 2018 - Agglomération > à 250 000 habitants ; 3.29 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
+  note: We make the (strong) assumption of an unweighted average to calculate the impact per km.
+  note.auto: We make the (strong) assumption of an unweighted average to calculate the impact per km.
+  note.lock: Nous faisons l'hypothèse (forte) d'une moyenne non pondérée pour le calcul de l'impact au km.
   titre: impact per km
   titre.auto: impact per km
   titre.lock: impact par km
@@ -26892,3 +26895,17 @@ logement . vacances . résidence secondaire . chauffage . facteur saison:
   titre: season factor
   titre.auto: season factor
   titre.lock: facteur saison
+transport . métro ou tram . impact par km RER:
+  titre: impact per km RER
+  titre.auto: impact per km RER
+  titre.lock: impact par km RER
+  note: RER and transilien/2022/Ile de France ; Base Carbone consulted on 06/12/2023
+  note.auto: RER and transilien/2022/Ile de France ; Base Carbone consulted on 06/12/2023
+  note.lock: RER et transilien/2022/Ile de France ; Base Carbone consultée le 06/12/2023
+transport . métro ou tram . impact par km métro:
+  titre: impact per metro km
+  titre.auto: impact per metro km
+  titre.lock: impact par km métro
+  note: Metro, tramway, trolleybus/2018/Agglomeration of 100,000 to 250,000 inhabitants ; Base Carbone consulted on 06/12/2023
+  note.auto: Metro, tramway, trolleybus/2018/Agglomeration of 100,000 to 250,000 inhabitants ; Base Carbone consulted on 06/12/2023
+  note.lock: Métro, tramway, trolleybus/2018/Agglomération de 100 000 à 250 000 habitants ; Base Carbone consultée le 06/12/2023

--- a/data/transport/métro ou tram.publicodes
+++ b/data/transport/métro ou tram.publicodes
@@ -1,21 +1,34 @@
 transport . métro ou tram:
-  titre: Métro ou tramway
+  titre: Métro, tramway, RER
   icônes: 🚊
   description: |
+    Il est question ici de tous les modes de transport urbains sur rails.
+
     ![](https://images.unsplash.com/photo-1581262208435-41726149a759?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60)
   formule: heures par semaine * impact par heure * commun . semaines par an
 
 transport . métro ou tram . impact par heure:
   formule: impact par km * vitesse
   unité: kgCO2e/h
-  note: Nous avons confondu tram et métro, alors que le modèle MicMac v2.6 ne parle que de métro.
-  description: |
-    Sur la base de 6,63 gCO2e/(passager.km) et de 25 km/h de vitesse moyenne.
+  description: Nous confondons l'ensemble des moyens de transport urbains sur rails, à savoir métro, tramway et RER.
 
 transport . métro ou tram . impact par km:
-  formule: 0.00329
+  formule:
+    moyenne:
+      - impact par km métro
+      - impact par km RER
   unité: kgCO2e/km
-  note: Métro, tramway, trolleybus - 2018 - Agglomération > à 250 000 habitants ; 3.29 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
+  note: Nous faisons l'hypothèse (forte) d'une moyenne non pondérée pour le calcul de l'impact au km.
+
+transport . métro ou tram . impact par km métro:
+  formule: 0.00503
+  unité: kgCO2e/km
+  note: Métro, tramway, trolleybus/2018/Agglomération de 100 000 à 250 000 habitants ; Base Carbone consultée le 06/12/2023
+
+transport . métro ou tram . impact par km RER:
+  formule: 0.00978
+  unité: kgCO2e/km
+  note: RER et transilien/2022/Ile de France ; Base Carbone consultée le 06/12/2023
 
 transport . métro ou tram . vitesse:
   formule: 25
@@ -23,7 +36,7 @@ transport . métro ou tram . vitesse:
   note: Hypothèse de 25 km/h de vitesse moyenne, d'après l'article [Les petits secrets de la RATP révélés au public](http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/)
 
 transport . métro ou tram . heures par semaine:
-  question: Combien d'heures passez-vous par semaine en métro ou en tram ?
+  question: Combien d'heures passez-vous par semaine en métro, tram, RER ?
   suggestions:
     zéro: 0
     1h / jour: 7


### PR DESCRIPTION
Pas si évident : la vitesse des RER est vraiment plus importante que le métro / tram. Le fait d'inclure l'impact du RER dans la question peut surestimer son empreinte (je fais plus de km en moins d'heures)

Preneur de votre avis @JuliePouliquen @mquandalle