### PR TITLE
Fix the crash in the compilation script in sync mode - [NGC-110]

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,3 +1,10 @@
+/**
+ * This script is only used to generate the model.json file packaged in the npm package.
+ *
+ * For complete compilation, see the ./scripts/rulesToJSON.mjs script
+ *
+ * TODO: this script should be abstracted into a standalone bin in @publicodes/tools
+ */
 import { writeFileSync } from 'fs'
 import { getModelFromSource } from '@publicodes/tools/compilation'
 import { disabledLogger } from '@publicodes/tools'

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@incubateur-ademe/nosgestesclimat-scripts": "^0.3.1",
     "@incubateur-ademe/publicodes-commun": "^0.1.2",
-    "@publicodes/tools": "^0.4.3",
+    "@publicodes/tools": "^0.4.4",
     "@types/glob": "^8.1.0",
     "ansi-colors": "^4.1.3",
     "cli-progress": "^3.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,13 +27,13 @@
   dependencies:
     publicodes "^1.0.0-beta.71"
 
-"@publicodes/tools@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@publicodes/tools/-/tools-0.4.3.tgz#7f0acc15f38ecde0521a0c665f459e7d210c47c1"
-  integrity sha512-TRMQ2As4YD9PbxOPhCiaA1ljC40X9w9dX/fA8siL1jr5fbRyiP/op6WOjsFa5Z/c5Y30DgSVd2kZm0NrBwIfrw==
+"@publicodes/tools@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@publicodes/tools/-/tools-0.4.4.tgz#44caada727eb235c6e1f40e595227ca10b04f7e3"
+  integrity sha512-wkRBoSpiWXAvBdQY9ByUbLVBSM9tnm+5I6SBVTFCLByp2iUjD57bgonFzAIBlDvBYHU3pCEnculJcFAq2G6Zew==
   dependencies:
     "@types/node" "^18.11.18"
-    publicodes "^1.0.0-beta.71"
+    publicodes "^1.0.0-beta.77"
 
 "@types/glob@^8.1.0":
   version "8.1.0"
@@ -48,10 +48,17 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
-"@types/node@*", "@types/node@>=12.0", "@types/node@^18.11.18":
+"@types/node@*", "@types/node@>=12.0":
   version "18.16.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.18.tgz#85da09bafb66d4bc14f7c899185336d0c1736390"
   integrity sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==
+
+"@types/node@^18.11.18":
+  version "18.19.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
+  integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
+  dependencies:
+    undici-types "~5.26.4"
 
 abbrev@1:
   version "1.1.1"
@@ -802,12 +809,7 @@ pstree.remy@^1.1.8:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-publicodes@^1.0.0-beta.71:
-  version "1.0.0-beta.76"
-  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-beta.76.tgz#07b740f18f4846aaa70b5a9c83109658c3c010c4"
-  integrity sha512-lnhRD4UIufN/N4T1LcgheEKX4bF6gSCYroE2po1Cfk0kkmgPn+ORKVT2M+HpHeVlTbPFAjVE1p5hL6P3zXUlLQ==
-
-publicodes@^1.0.0-beta.77:
+publicodes@^1.0.0-beta.71, publicodes@^1.0.0-beta.77:
   version "1.0.0-beta.77"
   resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-beta.77.tgz#45e3c4d2a46bfadcc932e1405ea037e659c28134"
   integrity sha512-F8U3WGUWMo3/rxhWYS1gWIiG20g1Yy/+PpXdHM99d6ZHKWnnyh/4txVEuyVE75glgDs+mTjwZPnmoKWsTMXluA==
@@ -1003,6 +1005,11 @@ undefsafe@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 union@~0.5.0:
   version "0.5.0"


### PR DESCRIPTION
The problem is that parsed rules from the engine use by the `constantFolding` function was [modified in place](https://github.com/publicodes/tools/pull/31) and this was a problem when called multiple times (I don't know why honestly).

This fixes https://github.com/publicodes/tools/issues/30 and improves some rule optimisations btw.

> [!IMPORTANT] 
> Doing a deep copy of the parsed rules noticeably degrades compilation performance. Therefore, this **should be considered as a temporary fix** while waiting to improve `constantFolding`.
> 
> `yarn compiles:rules`: from ~28s to 36s
> `yarn compiles:rules -o FR -t fr`: from ~3.71s to ~4.33s