### PR TITLE
Fix(t9n): correctly translate rules

### DIFF
--- a/.github/workflows/upload-compilation-result.yaml
+++ b/.github/workflows/upload-compilation-result.yaml
@@ -16,6 +16,7 @@ jobs:
       compilation-result: ${{ steps.compilation.outputs.result }}
       check-translation-result: ${{ steps.check-translation.outputs.result }}
       check-personas-result: ${{ steps.check-personas.outputs.result }}
+      test-translation-result: ${{ steps.test-translation.outputs.result }}
       test-personas-nightly-result: ${{ steps.test-personas-nightly.outputs.result }}
       test-personas-latest-result: ${{ steps.test-personas-latest.outputs.result }}
       test-optim-result: ${{ steps.test-optim.outputs.result }}
@@ -55,6 +56,15 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=result::${body}"
+      - id: test-translation
+        name: Test the translated rules against production
+        run: |
+          yarn test:translation --markdown > test-translation.res
+          body="$(cat test-translation.res | tail --lines=+3 | head --lines=-1)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=result::${body}"
       - id: test-personas-latest
         name: Test the personas bilans against production
         run: |
@@ -74,7 +84,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=result::${body}"
       - id: test-optim
-        name: # Test the personas bilans against production
+        name: Test the optimized rules against base rules
         run: |
           yarn test:optim --markdown > test-optim.res
           body="$(cat test-optim.res | tail --lines=+3 | head --lines=-1)"
@@ -117,6 +127,10 @@ jobs:
           ${{ needs.compile.outputs.check-personas-result }}
 
           > _You will find more information about the translation in the [dedicated file](https:/github.com/datagir/nosgestesclimat/blob/master/docs/translation.md)._
+
+          ### Test translation (fr -> en)
+
+          ${{ needs.compile.outputs.test-translation-result }}
 
           ---
 

--- a/.github/workflows/upload-compilation-result.yaml
+++ b/.github/workflows/upload-compilation-result.yaml
@@ -118,6 +118,8 @@ jobs:
 
           ### :globe_with_meridians: Translation status
 
+          > _You will find more information about the translation in the [dedicated file](https:/github.com/datagir/nosgestesclimat/blob/master/docs/translation.md)._
+
           #### Rules
 
           ${{ needs.compile.outputs.check-translation-result }}
@@ -126,9 +128,7 @@ jobs:
 
           ${{ needs.compile.outputs.check-personas-result }}
 
-          > _You will find more information about the translation in the [dedicated file](https:/github.com/datagir/nosgestesclimat/blob/master/docs/translation.md)._
-
-          ### Test translation (fr -> en)
+          #### Test translation (fr -> en)
 
           ${{ needs.compile.outputs.test-translation-result }}
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "doc": "yarn --cwd quick-doc run dev",
     "test:personas": "node tests/testPersonas.mjs",
     "test:optim": "node tests/testOptim.mjs",
+    "test:translation": "node tests/testTranslation.mjs",
+    "test": "yarn test:personas && yarn test:optim && yarn test:translation",
     "translate": "node scripts/i18n/translate-rules.js && node scripts/i18n/translate-personas.js",
     "check:personas": "node scripts/i18n/check-personas.js ",
     "translate:personas": "node scripts/i18n/translate-personas.js",

--- a/scripts/i18n/addTranslationToBaseRules.js
+++ b/scripts/i18n/addTranslationToBaseRules.js
@@ -15,7 +15,7 @@ const addTranslationToBaseRules = (baseRules, translatedRules) => {
     let baseRule = baseRules[ruleName]
     if (typeof baseRule !== 'object') {
       // for rules with formula directly implemented (ex: transport . empreinte au km covoiturage: 0.2 kgCO2e/km)
-      baseRule = { ['formule']: baseRules[ruleName] }
+      baseRules[ruleName] = { valeur: baseRules[ruleName] }
     }
     if (
       baseRule &&

--- a/scripts/i18n/addTranslationToBaseRules.js
+++ b/scripts/i18n/addTranslationToBaseRules.js
@@ -8,6 +8,8 @@
 const utils = require('@incubateur-ademe/nosgestesclimat-scripts/utils')
 const cli = require('@incubateur-ademe/nosgestesclimat-scripts/cli')
 
+const attrSuffixesToIgnore = ['.lock', '.auto', '.previous_review']
+
 const addTranslationToBaseRules = (baseRules, translatedRules) => {
   const updateBaseRules = (ruleName, attributes, val) => {
     let baseRule = baseRules[ruleName]
@@ -47,7 +49,9 @@ const addTranslationToBaseRules = (baseRules, translatedRules) => {
     let baseRule = baseRules[rule]
     if (baseRule) {
       Object.entries(attrs)
-        .filter(([attr, _]) => !attr.endsWith('.lock'))
+        .filter(([attr, _]) =>
+          attrSuffixesToIgnore.every((s) => !attr.endsWith(s))
+        )
         .forEach(([attr, transVal]) => {
           switch (attr) {
             case 'suggestions': {

--- a/tests/testTranslation.mjs
+++ b/tests/testTranslation.mjs
@@ -14,6 +14,7 @@ Promise.all([localFrRules, localPersonas, localEnRules]).then((res) => {
   const engineFr = new Engine(res[0], { logger: disabledLogger })
   const engineEn = new Engine(res[2], { logger: disabledLogger })
 
+  const nbRules = Object.keys(res[0]).length
   const errors = []
 
   for (const rule in res[0]) {
@@ -30,7 +31,7 @@ Promise.all([localFrRules, localPersonas, localEnRules]).then((res) => {
 
   if (markdown) {
     console.log(`| Règle | fr | en |`)
-    console.log(`| --- | --- | --- |`)
+    console.log(`| :-- | :-- | :-- |`)
     for (const error of errors) {
       console.log(`| ${error.rule} | ${error.fr} | ${error.en} |`)
     }
@@ -41,11 +42,8 @@ Promise.all([localFrRules, localPersonas, localEnRules]).then((res) => {
       console.log(`${c.magenta(error.rule)}: ${error.fr} !== ${error.en}`)
     }
 
-    if (errors.length > 0) {
-      console.log(
-        `\n${c.red('FAIL')} ${errors.length}/${Object.keys(res[0]).length}`
-      )
-      exit(-1)
-    }
+    console.log(
+      `\n${errors.length > 0 ? c.red('FAIL') : c.green('OK')} ${nbRules - errors.length}/${nbRules}`
+    )
   }
 })

--- a/tests/testTranslation.mjs
+++ b/tests/testTranslation.mjs
@@ -1,0 +1,51 @@
+import { getArgs, getLocalRules, getLocalPersonas } from './commons.mjs'
+import c from 'ansi-colors'
+import { disabledLogger } from '@publicodes/tools'
+import Engine from 'publicodes'
+
+const { country, markdown } = getArgs()
+
+const localEnRules = getLocalRules(country, 'en')
+const localFrRules = getLocalRules(country, 'fr')
+
+const localPersonas = getLocalPersonas(country, 'fr')
+
+Promise.all([localFrRules, localPersonas, localEnRules]).then((res) => {
+  const engineFr = new Engine(res[0], { logger: disabledLogger })
+  const engineEn = new Engine(res[2], { logger: disabledLogger })
+
+  const errors = []
+
+  for (const rule in res[0]) {
+    try {
+      const fr = engineFr.evaluate(rule).nodeValue
+      const en = engineEn.evaluate(rule).nodeValue
+      if (fr !== en) {
+        errors.push({ rule, fr, en })
+      }
+    } catch (e) {
+      errors.push({ rule, fr: e.message, en: null })
+    }
+  }
+
+  if (markdown) {
+    console.log(`| Règle | fr | en |`)
+    console.log(`| --- | --- | --- |`)
+    for (const error of errors) {
+      console.log(`| ${error.rule} | ${error.fr} | ${error.en} |`)
+    }
+  } else {
+    console.log('[ Test model translation (fr/en)]\n')
+
+    for (const error of errors) {
+      console.log(`${c.magenta(error.rule)}: ${error.fr} !== ${error.en}`)
+    }
+
+    if (errors.length > 0) {
+      console.log(
+        `\n${c.red('FAIL')} ${errors.length}/${Object.keys(res[0]).length}`
+      )
+      exit(-1)
+    }
+  }
+})


### PR DESCRIPTION
Removes `.auto` and `.previous_review` attributes from the translated rules and fix a problem with *inlined* rules (i.e `rule: oui`) translation. It adds a new `testTranslation` script that compares result for each rule between `fr` and `en` models.  