### PR TITLE
Correction action passer végé - NGC-540

### DIFF
--- a/data/actions/alimentation.publicodes
+++ b/data/actions/alimentation.publicodes
@@ -195,7 +195,7 @@ alimentation . devenir végétarien . différence par semaine:
   unité: kgCO2e/semaine
 
 alimentation . devenir végétarien . différence par semaine repas:
-  formule: plats - une semaine plats végétarien
+  formule: plats - recalcul
   unité: kgCO2e/semaine
 
 alimentation . devenir végétarien . différence par semaine petits déjeuners:
@@ -203,8 +203,19 @@ alimentation . devenir végétarien . différence par semaine petits déjeuners:
   formule: alimentation . petit déjeuner . par semaine - une semaine petit déjeuner végétalien
   unité: kgCO2e/semaine
 
-alimentation . une semaine plats végétarien:
-  formule: 14 repas/semaine * plats . végétarien . empreinte
+alimentation . devenir végétarien . recalcul:
+  formule:
+    recalcul:
+      règle: plats
+      avec:
+        plats . viande 1: 0
+        plats . viande 2: 0
+        plats . végétarien: somme des plats non végé * plats . végétarien . empreinte
+        plats . poisson 1: 0
+        plats . poisson 2: 0
+
+alimentation . devenir végétarien . somme des plats non végé: 
+  formule: nombre de plats viande + nombre de plats poisson
 
 alimentation . devenir végétalien:
   applicable si:

--- a/data/actions/alimentation.publicodes
+++ b/data/actions/alimentation.publicodes
@@ -190,12 +190,8 @@ alimentation . devenir végétarien . différence par semaine:
   titre: Différence par semaine
   formule:
     somme:
-      - différence par semaine repas
       - différence par semaine petits déjeuners
-  unité: kgCO2e/semaine
-
-alimentation . devenir végétarien . différence par semaine repas:
-  formule: plats - recalcul
+      - différence par semaine repas
   unité: kgCO2e/semaine
 
 alimentation . devenir végétarien . différence par semaine petits déjeuners:
@@ -203,19 +199,28 @@ alimentation . devenir végétarien . différence par semaine petits déjeuners:
   formule: alimentation . petit déjeuner . par semaine - une semaine petit déjeuner végétalien
   unité: kgCO2e/semaine
 
-alimentation . devenir végétarien . recalcul:
+alimentation . devenir végétarien . différence par semaine repas:
+  formule: plats - recalcul
+  unité: kgCO2e/semaine
+
+alimentation . devenir végétarien . différence par semaine repas . recalcul:
   formule:
     recalcul:
       règle: plats
       avec:
+        plats . végétarien . nombre: nouveau nombre plats végé
         plats . viande 1: 0
         plats . viande 2: 0
-        plats . végétarien: somme des plats non végé * plats . végétarien . empreinte
         plats . poisson 1: 0
         plats . poisson 2: 0
 
-alimentation . devenir végétarien . somme des plats non végé: 
+alimentation . devenir végétarien . différence par semaine repas . nouveau nombre plats végé:
+  formule: plats . végétarien . nombre + nombre plats non végé
+  unité: repas/semaine
+
+alimentation . devenir végétarien . différence par semaine repas . nombre plats non végé:
   formule: nombre de plats viande + nombre de plats poisson
+  unité: repas/semaine
 
 alimentation . devenir végétalien:
   applicable si:

--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -3826,10 +3826,6 @@ alimentation . une semaine plats végétalien:
   titre: one week vegan dishes
   titre.auto: one week vegan dishes
   titre.lock: une semaine plats végétalien
-alimentation . une semaine plats végétarien:
-  titre: one week vegetarian dishes
-  titre.auto: one week vegetarian dishes
-  titre.lock: une semaine plats végétarien
 alimentation . viande faible empreinte:
   description: |
     The climate footprint of our food is directly correlated to our meat consumption, but not all meat is created equal.
@@ -14876,7 +14872,7 @@ commun . jours par an:
   titre.lock: Nombre de jours par an
   description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun)."
 logement:
   abréviation: hous.
   abréviation.auto: logmt.
@@ -16702,7 +16698,7 @@ commun . mois par an:
   titre.lock: Nombre de mois par an
   description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun)."
 parc français:
   description: |
     The objective of this small model is to estimate the average values associated with the dwelling (surface, surface heated with gas, consumption by heating...) to obtain a total average footprint of the dwelling which is representative of the average French person
@@ -17029,7 +17025,7 @@ commun . semaines par an:
   titre.lock: Nombre de semaines par an
   description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun)."
 services marchands:
   abréviation: S. merchants
   abréviation.auto: S. merchants
@@ -17909,26 +17905,26 @@ transport . boulot . jours travaillés en voiture:
   question.auto: How many days a week do you drive to work?
   question.lock: Combien de jours par semaine prenez-vous votre voiture pour aller au travail ?
   suggestions:
-    - '0'
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "0"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   suggestions.auto:
-    - '0'
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "0"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   suggestions.lock:
-    - '0'
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "0"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   titre: days worked by car
   titre.auto: days worked by car
   titre.lock: jours travaillés en voiture
@@ -20112,14 +20108,14 @@ futureco-data . transport . ferry . empreinte totale . par km:
   titre.lock: par km
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . km par mille nautique:
   titre: km per nautical mile
   titre.auto: km per nautical mile
   titre.lock: km par mille nautique
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . empreinte par km volume:
   titre: Footprint per km and passenger
   titre.auto: Footprint per km and passenger
@@ -20256,14 +20252,14 @@ futureco-data . transport . ferry . empreinte totale:
   titre.lock: empreinte totale
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . part du volume:
   titre: Share of the useful volume of the boat attributed to the passenger
   titre.auto: Share of the useful volume of the boat attributed to the passenger
   titre.lock: Part du volume utile du bateau attribuée au passager
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . surface . communs:
   titre: common
   titre.auto: common
@@ -20319,7 +20315,7 @@ futureco-data . transport . ferry . volume passager:
     ⚠️ C'est peut-être une hypothèse trop favorable qui pourrait donner lieu à une sous-estimation de 30% voir 100%.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . durée du voyage:
   titre: travel time
   titre.auto: travel time
@@ -20372,7 +20368,7 @@ futureco-data . transport . ferry . volume garage:
   titre.lock: volume garage
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . cabines nécessaires:
   titre: cabins required
   titre.auto: cabins required
@@ -20422,7 +20418,7 @@ futureco-data . transport . ferry . vitesse:
   question.lock: Quelle est la vitesse du ferry ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . distance aller:
   titre: distance one way
   titre.auto: distance one way
@@ -20454,7 +20450,7 @@ futureco-data . transport . ferry . surface . garage:
   titre.lock: garage
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . surface . sièges:
   titre: seats
   titre.auto: seats
@@ -20464,35 +20460,35 @@ futureco-data . transport . ferry . surface . sièges:
   question.lock: Quelle est la surface totale des sièges ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . vitesse en kmh:
   titre: speed in kmh
   titre.auto: speed in kmh
   titre.lock: vitesse en kmh
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . cabine partagée:
   titre: shared cabin
   titre.auto: shared cabin
   titre.lock: cabine partagée
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . cabine:
   titre: cabin
   titre.auto: cabin
   titre.lock: cabine
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . rapport vitesse:
   titre: speed ratio
   titre.auto: speed ratio
   titre.lock: rapport vitesse
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . facteur vitesse:
   description: |-
 
@@ -20524,7 +20520,7 @@ futureco-data . transport . ferry . surface . garage . haut:
   question.lock: Quelle est la surface de garage haut du bateau ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . voiture:
   titre: car
   titre.auto: car
@@ -20537,7 +20533,7 @@ futureco-data . transport . ferry . volume passager . voiture:
     Ici nous décidons de ne pas voir la capacité en voiture et diviser la surface voiture par ce nombre, car les différentes zones de garage peuvent accomoder aussi bien des voitures que des camions.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume utile:
   description: |
 
@@ -20578,7 +20574,7 @@ futureco-data . transport . ferry . cabine . nombre:
   question.lock: Quel est le nombre total de cabines passager ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 transport . ferry . heures:
   titre: Ferry hours in the year
   titre.auto: Ferry hours in the year
@@ -20655,14 +20651,14 @@ futureco-data . transport . ferry . groupe:
   question.lock: À combien voyagez-vous ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . consommation de services:
   titre: consumption of services
   titre.auto: consumption of services
   titre.lock: consommation de services
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
   question: Do you use the ferry's ancillary services (bar, restaurant, swimming pool, etc.)?
   question.auto: Do you use the ferry's ancillary services (bar, restaurant, swimming pool, etc.)?
   question.lock: Utilisez vous les services accessoires du ferry (bar, restaurant, piscine, etc.) ?
@@ -20753,7 +20749,7 @@ futureco-data . transport . ferry . vitesse moyenne . métrique:
   titre.lock: Vitesse moyenne ferry
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . empreinte totale moyenne:
   titre: average total footprint
   titre.auto: average total footprint
@@ -20766,7 +20762,7 @@ futureco-data . transport . ferry . empreinte totale moyenne:
     Données greenferries 2020 tirées de Thetis-MRV 2020 https://mrv.emsa.europa.eu/#public/emission-report
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . voiture:
   titre: car
   titre.auto: car
@@ -20887,7 +20883,7 @@ futureco-data . transport . ferry . hauteur pont bas:
   titre.lock: hauteur pont bas
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . passagers:
   titre: Average passengers
   titre.auto: Average passengers
@@ -20928,7 +20924,7 @@ futureco-data . transport . ferry . surface . siège:
   titre.lock: siège
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . hauteur pont haut:
   titre: height of high bridge
   titre.auto: height of high bridge
@@ -20938,7 +20934,7 @@ futureco-data . transport . ferry . hauteur pont haut:
   note.lock: Nous simplifions pour l'instant ces données qui pourront être améliorées dans un second temps.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . voiture . majoré:
   note: We assume that some cars park in a garage with a high deck height, so let's apply the area-weighted average.
   note.auto: We assume that some cars park in a garage with a high deck height, so let's apply the area-weighted average.
@@ -20948,7 +20944,7 @@ futureco-data . transport . ferry . volume passager . voiture . majoré:
   titre.lock: Volume garage voiture
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . surface . garage . bas:
   titre: bottom
   titre.auto: bottom
@@ -20958,21 +20954,21 @@ futureco-data . transport . ferry . surface . garage . bas:
   question.lock: Quelle est la surface de garage bas du bateau ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . loisirs:
   titre: leisure
   titre.auto: leisure
   titre.lock: loisirs
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . vitesse moyenne:
   titre: average speed
   titre.auto: average speed
   titre.lock: vitesse moyenne
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . voiture . largeur:
   titre: width
   titre.auto: width
@@ -21001,14 +20997,14 @@ futureco-data . transport . ferry . hauteur moyenne garage:
   titre.lock: hauteur moyenne garage
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume communs:
   titre: common volumes
   titre.auto: common volumes
   titre.lock: volume communs
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . surface . loisirs:
   titre: leisure
   titre.auto: leisure
@@ -21040,14 +21036,14 @@ futureco-data . transport . ferry . surface . cabine:
   titre.lock: cabine
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . billet cabine:
   titre: cabin ticket
   titre.auto: cabin ticket
   titre.lock: billet cabine
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . siège . nombre:
   titre: number
   titre.auto: number
@@ -21057,7 +21053,7 @@ futureco-data . transport . ferry . siège . nombre:
   question.lock: Quel est le nombre total de sièges passager ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . surface . cabines:
   titre: cabins
   titre.auto: cabins
@@ -21067,21 +21063,21 @@ futureco-data . transport . ferry . surface . cabines:
   question.lock: Quelle est la surface totale des cabines ?
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . communs:
   titre: common
   titre.auto: common
   titre.lock: communs
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 futureco-data . transport . ferry . volume passager . siège:
   titre: A seat in a dormitory
   titre.auto: A seat in a dormitory
   titre.lock: Un siège dans un dortoir
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . vacances:
   titre: Weekend or vacation nights
   titre.auto: Weekend or vacation nights
@@ -22381,7 +22377,7 @@ logement . piscine . construction . terrassement:
   titre.lock: terrassement
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . équipement nautique:
   titre: nautical equipment
   titre.auto: nautical equipment
@@ -22416,28 +22412,28 @@ logement . piscine . construction . béton . type . volume:
   titre.lock: volume
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . étanchéité:
   titre: sealing
   titre.auto: sealing
   titre.lock: étanchéité
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . béton . masse volumique:
   titre: density
   titre.auto: density
   titre.lock: masse volumique
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . lot technique:
   titre: technical package
   titre.auto: technical package
   titre.lock: lot technique
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . traitement chimique:
   titre: chemical treatment
   titre.auto: chemical treatment
@@ -22456,14 +22452,14 @@ logement . piscine . traitement chimique:
     On ignore aussi le transport du chlore acheté, en pratique souvent en voiture, ce qui implique une consommation d'essence non négligeable mais de second ordre a priori.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction:
   titre: construction
   titre.auto: construction
   titre.lock: construction
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . abri:
   titre: shelter
   titre.auto: shelter
@@ -22498,42 +22494,42 @@ logement . piscine . construction . durée de vie:
     Nous avons dans un premier temps pris cette estimation, qui semble un peu basse pour le béton (qui est estimé davantage à 40 ans), mais plutôt réaliste pour le reste des équipements. C'est un paramètre à faire évoluer au besoin.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . divers chantier:
   titre: various worksites
   titre.auto: various worksites
   titre.lock: divers chantier
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . béton . type . épaisseur:
   titre: thickness
   titre.auto: thickness
   titre.lock: épaisseur
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . béton . type . volume parallélépipède:
   titre: parallelepiped volume
   titre.auto: parallelepiped volume
   titre.lock: volume parallélépipède
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . béton . empreinte:
   titre: footprint
   titre.auto: footprint
   titre.lock: empreinte
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . béton . masse:
   titre: mass
   titre.auto: mass
   titre.lock: masse
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . plage pierre:
   titre: Stone beach
   titre.auto: Stone beach
@@ -22562,7 +22558,7 @@ logement . piscine . construction . béton:
   titre.lock: béton
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . masse de chlore:
   titre: chlorine mass
   titre.auto: chlorine mass
@@ -22615,14 +22611,14 @@ logement . piscine . construction . béton . type . masse:
   titre.lock: masse
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . type . surface . murs:
   titre: walls
   titre.auto: walls
   titre.lock: murs
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . type . surface:
   titre: surface
   titre.auto: surface
@@ -22651,14 +22647,14 @@ logement . piscine . construction . béton . type . volume plage:
   titre.lock: volume plage
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . étanchéité . liner . quantité:
   titre: quantity
   titre.auto: quantity
   titre.lock: quantité
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . profondeur:
   titre: depth
   titre.auto: depth
@@ -22668,28 +22664,28 @@ logement . piscine . profondeur:
   note.lock: Nous partons sur une profondeur moyenne d'eau de 1m50, par exemple une pente linéaire de 1m à 2m.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . surface plage:
   titre: beach surface
   titre.auto: beach surface
   titre.lock: surface plage
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . volume:
   titre: volume
   titre.auto: volume
   titre.lock: volume
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . empreinte pierre:
   titre: stone imprint
   titre.auto: stone imprint
   titre.lock: empreinte pierre
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . empreinte chlore:
   titre: chlorine footprint
   titre.auto: chlorine footprint
@@ -22699,28 +22695,28 @@ logement . piscine . empreinte chlore:
   note.lock: Nous prenons l'empreinte du Cl2, chlore gazeux liquéfié dans le document en référence ci-dessous.
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . étanchéité . liner:
   titre: liner
   titre.auto: liner
   titre.lock: liner
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . étanchéité . liner . empreinte PVC:
   titre: pVC footprint
   titre.auto: pVC footprint
   titre.lock: empreinte PVC
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . empreinte empirique:
   titre: empirical footprint
   titre.auto: empirical footprint
   titre.lock: empreinte empirique
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
   note: |
     The figures in this namespace come mainly from the calculation <a href="https://user-images.githubusercontent.com/1177762/245216468-760f16f8-59f4-447f-a1e5-862fcdb08980.png">presented on this A4 sheet</a>.
   note.auto: |
@@ -22733,21 +22729,21 @@ logement . piscine . empreinte eau froide:
   titre.lock: empreinte eau froide
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . lot technique . pompe:
   titre: pump
   titre.auto: pump
   titre.lock: pompe
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . maçonnerie:
   titre: masonry
   titre.auto: masonry
   titre.lock: maçonnerie
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine:
   titre: pool
   titre.auto: pool
@@ -22872,7 +22868,7 @@ logement . piscine . correcteur surface type:
   titre.lock: correcteur surface type
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . présent:
   titre: present
   titre.auto: present
@@ -22904,7 +22900,7 @@ logement . piscine . construction . divers chantier . gasoil:
   titre.lock: gasoil
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . lot technique . électricité:
   titre: electricity
   titre.auto: electricity
@@ -22979,28 +22975,28 @@ logement . piscine . construction . divers chantier . livraison:
   titre.lock: livraison
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . étanchéité . liner . durée de vie:
   titre: Liner lifetime
   titre.auto: Liner lifetime
   titre.lock: Durée de vie du liner
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . terrassement . empreinte diesel:
   titre: diesel footprint
   titre.auto: diesel footprint
   titre.lock: empreinte diesel
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . divers chantier . consommable:
   titre: consumables
   titre.auto: consumables
   titre.lock: consommable
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . type . surface . parallélépipède:
   titre: parallelepiped
   titre.auto: parallelepiped
@@ -23035,14 +23031,14 @@ logement . piscine . construction . étanchéité . liner . surface:
   titre.lock: surface
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 logement . piscine . construction . terrassement . conso diesel:
   titre: diesel consumption
   titre.auto: diesel consumption
   titre.lock: conso diesel
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
 divers . tabac . nombre de cigarettes par paquet:
   titre: number of cigarettes per pack
   titre.auto: number of cigarettes per pack
@@ -23962,21 +23958,21 @@ divers . loisirs . culture . musées et monuments . proportion de visiteurs:
 logement . eau . impact par litre froid:
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
   titre: impact by cold liter
   titre.auto: impact by cold liter
   titre.lock: impact par litre froid
 logement . eau . impact par litre froid . traitement eau usée:
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
   titre: wastewater treatment
   titre.auto: wastewater treatment
   titre.lock: traitement eau usée
 logement . eau . impact par litre froid . eau potable:
   description: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/laem/futureco-data">`futureco-data`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`futureco-data`](https://github.com/laem/futureco-data)."
   titre: drinking water
   titre.auto: drinking water
   titre.lock: eau potable
@@ -24837,7 +24833,7 @@ commun . jours par semaine:
   titre.lock: Nombre de jours par semaine
   description: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
   description.auto: '> ℹ️ This rule comes from the <a href="https://github.com/incubateur-ademe/publicodes-commun">`@incubator-ademe/publicodes-commun`</a> model.'
-  description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun).'
+  description.lock: "> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-commun`](https://github.com/incubateur-ademe/publicodes-commun)."
 transport . voiture . km annuels moyen:
   note: Figure taken from <a href="https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0">datalab ministère écologie 2019</a>, page 3 G1.
   note.auto: Figure taken from <a href="https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0">datalab ministère écologie 2019</a>, page 3 G1.
@@ -27206,23 +27202,23 @@ transport . boulot . télétravail . jours gagnés:
   titre.lock: jours gagnés
 transport . boulot . télétravail . jours télétravaillés:
   suggestions:
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   suggestions.auto:
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   suggestions.lock:
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   titre: days teleworked
   titre.auto: days teleworked
   titre.lock: jours télétravaillés
@@ -27704,3 +27700,15 @@ logement . climatisation . part électricité climatisation:
   titre: share of electricity for air-conditioning
   titre.auto: share of electricity for air-conditioning
   titre.lock: part électricité climatisation
+alimentation . devenir végétarien . différence par semaine repas . recalcul:
+  titre: recalculation
+  titre.auto: recalculation
+  titre.lock: recalcul
+alimentation . devenir végétarien . différence par semaine repas . nouveau nombre plats végé:
+  titre: new number of vegetarian dishes
+  titre.auto: new number of vegetarian dishes
+  titre.lock: nouveau nombre plats végé
+alimentation . devenir végétarien . différence par semaine repas . nombre plats non végé:
+  titre: number of non-veg dishes
+  titre.auto: number of non-veg dishes
+  titre.lock: nombre plats non végé


### PR DESCRIPTION
Correction par un recalcul qui ne transforme que les plats viande et poissons en plats végés, et non l'intégralité des 14 repas.