### PR TITLE
allow only publicodes dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
           - 'dotenv'
           - 'deepl-node'
           - 'ramda'
+          - 'express'
     allow:
       - dependency-name: publicodes-dependencies
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,5 +27,9 @@ updates:
           - 'dotenv'
           - 'deepl-node'
           - 'ramda'
+    allow:
+      - dependency-name: publicodes-dependencies
+    ignore:
+      - dependency-name: dev-dependencies
     labels:
       - 'dependencies'


### PR DESCRIPTION
Pour avoir seulement des PR pour ce qui concerne les dépendances publicodes
