### PR TITLE
Fix FE poisson NGC-878

### DIFF
--- a/data/alimentation/repas.publicodes
+++ b/data/alimentation/repas.publicodes
@@ -250,7 +250,7 @@ alimentation . plats . poisson gras:
 
 alimentation . plats . poisson gras . empreinte:
   titre: Empreinte d'un repas de type poisson gras (thon, saumon, sardine, maquereau)
-  formule: 1.09
+  formule: 1.31
   unité: kgCO2e/repas
   note: |
     L'empreinte d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
@@ -262,9 +262,9 @@ alimentation . plats . poisson gras . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **1,09** |
+    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 

--- a/data/alimentation/repas.publicodes
+++ b/data/alimentation/repas.publicodes
@@ -284,7 +284,7 @@ alimentation . plats . poisson blanc:
 
 alimentation . plats . poisson blanc . empreinte:
   titre: Empreinte d'un repas de type poisson blanc
-  formule: 1.92
+  formule: 2.14
   unité: kgCO2e/repas
   note: |
     L'empreinte d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
@@ -296,9 +296,9 @@ alimentation . plats . poisson blanc . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **1,92** |
+    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 

--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -27061,10 +27061,10 @@ alimentation . plats . poisson blanc . empreinte:
     | White fish | PB | 150 | 127,71 | 27,81 | 1,82 | 9,36 | 1,4 |
     | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
     | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | 13014 | 200 | 77.2 | 1.26 | 0 | 0.48 | 0.1 |
+    | **Dessert** | | | | | | | | |
+    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
     | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 584.02 | 48.93 | 10.33 | **1.92** |
+    | Total | 705 | 693.21 | 53.03 | 22.44 | **2.14** |
 
     💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
   note.auto: |
@@ -27076,10 +27076,10 @@ alimentation . plats . poisson blanc . empreinte:
     | White fish | PB | 150 | 127,71 | 27,81 | 1,82 | 9,36 | 1,4 |
     | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
     | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | 13014 | 200 | 77.2 | 1.26 | 0 | 0.48 | 0.1 |
+    | **Dessert** | | | | | | | | |
+    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
     | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 584.02 | 48.93 | 10.33 | **1.92** |
+    | Total | 705 | 693.21 | 53.03 | 22.44 | **2.14** |
 
     💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
   note.lock: |
@@ -27092,9 +27092,9 @@ alimentation . plats . poisson blanc . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **1,92** |
+    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 alimentation . plats . poisson gras . empreinte:
@@ -27107,10 +27107,10 @@ alimentation . plats . poisson gras . empreinte:
     | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 3,85 | 0,58 |
     | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
     | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | 13014 | 200 | 77.2 | 1.26 | 0 | 0.48 | 0.1 |
+    | **Dessert** | | | | | | | | |
+    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
     | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 746.57 | 54.28 | 25.67 | **1.09** |
+    | Total | 705 | 855,77 | 58,38 | 37,79 | **1,31** |
 
     💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
   note.auto: |
@@ -27122,10 +27122,10 @@ alimentation . plats . poisson gras . empreinte:
     | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 3,85 | 0,58 |
     | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
     | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | 13014 | 200 | 77.2 | 1.26 | 0 | 0.48 | 0.1 |
+    | **Dessert** | | | | | | | | |
+    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
     | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 746.57 | 54.28 | 25.67 | **1.09** |
+    | Total | 705 | 855,77 | 58,38 | 37,79 | **1,31** |
 
     💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
   note.lock: |
@@ -27138,9 +27138,9 @@ alimentation . plats . poisson gras . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **1,09** |
+    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
   titre: Footprint of a meal of oily fish (tuna, salmon, sardines, mackerel)

--- a/data/i18n/t9n/translated-rules-es.yaml
+++ b/data/i18n/t9n/translated-rules-es.yaml
@@ -1717,33 +1717,33 @@ alimentation . empreinte lait de vache:
   titre.lock: empreinte lait de vache
 alimentation . plats . poisson gras . empreinte:
   note: |
-    La huella de una comida en la que predomina el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en el cuadro siguiente:
+    La huella de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en la siguiente tabla:
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
+    | CIQUAL | Qte (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
     | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
     | **Enterée + plat principal** | | | | | | | | | | |
     | Pescado graso PG 150 290,27 33,16 17,16 3,85 0,58
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
+    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
     | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio 13014 200 77,2 1,26 0,48 0,1
+    | **Postre** | | | | | | | | | | |
+    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
     | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 746,57, 54,28, 25,67, 1,09
+    | Total: 705, 855,77, 58,38, 37,79, **1,31**
 
     💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
   note.auto: |
-    La huella de una comida en la que predomina el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en el cuadro siguiente:
+    La huella de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en la siguiente tabla:
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
+    | CIQUAL | Qte (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
     | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
     | **Enterée + plat principal** | | | | | | | | | | |
     | Pescado graso PG 150 290,27 33,16 17,16 3,85 0,58
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
+    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
     | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio 13014 200 77,2 1,26 0,48 0,1
+    | **Postre** | | | | | | | | | | |
+    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
     | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 746,57, 54,28, 25,67, 1,09
+    | Total: 705, 855,77, 58,38, 37,79, **1,31**
 
     💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
   note.lock: |
@@ -1756,9 +1756,9 @@ alimentation . plats . poisson gras . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **1,09** |
+    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
   titre: Huella de una comida de pescado azul (atún, salmón, sardinas, caballa)
@@ -1779,12 +1779,12 @@ alimentation . plats . poisson blanc . empreinte:
     | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
     | **Enterée + plat principal** | | | | | | | | | | |
     | Pescado blanco PB 150 127,71 27,81 1,82 9,36 1,4
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
+    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
     | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio 13014 200 77,2 1,26 0,48 0,1
+    | **Postre** | | | | | | | | | |
+    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
     | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 584,02, 48,93, 10,33, 1,92
+    | Total: 705, 693,21, 53,03, 22,44, **2,14**
 
     💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
   note.auto: |
@@ -1794,12 +1794,12 @@ alimentation . plats . poisson blanc . empreinte:
     | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
     | **Enterée + plat principal** | | | | | | | | | | |
     | Pescado blanco PB 150 127,71 27,81 1,82 9,36 1,4
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
+    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
     | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio 13014 200 77,2 1,26 0,48 0,1
+    | **Postre** | | | | | | | | | |
+    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
     | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 584,02, 48,93, 10,33, 1,92
+    | Total: 705, 693,21, 53,03, 22,44, **2,14**
 
     💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
   note.lock: |
@@ -1812,9 +1812,9 @@ alimentation . plats . poisson blanc . empreinte:
     | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
     | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
     |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | 13014  | 200     | 77,2   | 1,26          | 0           | 0,48      |  0,1     |
+    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
     | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **1,92** |
+    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 alimentation . plats . végétarien . empreinte:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:optim": "node tests/testOptim.mjs",
     "test:translation": "node tests/testTranslation.mjs",
     "test": "yarn test:personas && yarn test:optim && yarn test:translation",
-    "translate": "node scripts/i18n/translate-rules.js && node scripts/i18n/translate-personas.js",
+    "translate": "node scripts/i18n/translate-rules.mjs && node scripts/i18n/translate-personas.js",
     "check:personas": "node scripts/i18n/check-personas.js ",
     "translate:personas": "node scripts/i18n/translate-personas.js",
     "check:rules": "node scripts/i18n/check-translation.mjs",


### PR DESCRIPTION
Une erreur s'était introduite dans le fichier Excel : les données pour le dessert n'étaient pas bonnes, et le repas poisson était délesté de quelques 300gCO2e / repas.