### PR TITLE
Fix unités aide saisie - NGC-935

### DIFF
--- a/data/logement/électricité.publicodes
+++ b/data/logement/électricité.publicodes
@@ -163,11 +163,11 @@ logement . électricité . photovoltaique . production estimée via la puissance
     Pas de relevé ? Entrez ici votre puissance installée.
 
     _(Sachez qu'en moyenne, 1 panneau = 400 Wc)_
-  unité: kWc
+  unité: Wc
 
 logement . électricité . photovoltaique . production estimée via la puissance installée . facteur:
-  formule: 1300
-  unité: kWh/kWc
+  formule: 1.3
+  unité: kWh/Wc
 
 logement . électricité . photovoltaique . autoconsommation:
   formule: production * part autoconsommation


### PR DESCRIPTION
L'indication parlait de Wc, quand l'unité attendue était du kWc. Un facteur 1000 qui n'aide pas à s'y retrouver.