### PR TITLE
Mise jour données Agribalyse NGC-1078

### DIFF
--- a/.github/workflows/pr-updater.yaml
+++ b/.github/workflows/pr-updater.yaml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v2.3.4
 
       - name: Downloading Artifacts from Previous Workflow...
-        uses: dawidd6/action-download-artifact@v2
+        uses: synergy-au/download-workflow-artifacts-action@v1
         with:
-          workflow: 'upload-compilation-result.yaml'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
 
       - name: Updating the PR
         uses: actions/github-script@v6

--- a/.github/workflows/pr-updater.yaml
+++ b/.github/workflows/pr-updater.yaml
@@ -14,13 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Downloading Artifacts from Previous Workflow...
-        uses: synergy-au/download-workflow-artifacts-action@v1
+        uses: dawidd6/action-download-artifact@v2
         with:
-          auth-token: ${{ secrets.GITHUB_TOKEN }}
-          workflow-run-id: ${{ github.event.workflow_run.id }}
+          workflow: 'upload-compilation-result.yaml'
 
       - name: Updating the PR
         uses: actions/github-script@v6

--- a/.github/workflows/pr-updater.yaml
+++ b/.github/workflows/pr-updater.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
 
       - name: Downloading Artifacts from Previous Workflow...
         uses: synergy-au/download-workflow-artifacts-action@v1

--- a/.github/workflows/upload-compilation-result.yaml
+++ b/.github/workflows/upload-compilation-result.yaml
@@ -123,7 +123,7 @@ jobs:
 
           " > artifacts/result.md
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: pr_message
           path: artifacts

--- a/data/alimentation/repas.publicodes
+++ b/data/alimentation/repas.publicodes
@@ -25,21 +25,21 @@ alimentation . déforestation:
             - sinon: forfait base + (forfait moyen fruits céréales * 0.2)
       - sinon: 0
   note: |
-    La déforestation importée est l'empreinte carbone associée à la destruction de forêts ailleurs sur la planète. Elle est la combinaison de deux facteurs : 
+    La déforestation importée est l'empreinte carbone associée à la destruction de forêts ailleurs sur la planète. Elle est la combinaison de deux facteurs :
 
     - Les émissions liées au brûlage de la forêt (instantanées)
     - Les émissions liées à la suppression de puits de carbone (futures)
 
-    L’étude [Pendril & al.](https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41) est la plus complète sur les émissions liées à la déforestation importée. 
+    L’étude [Pendril & al.](https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41) est la plus complète sur les émissions liées à la déforestation importée.
 
     Une part de ces émissions est à faire varier en fonction du régime alimentaire. Elle concerne :
 
-    - les consommations de viande (en fonction du nombre de repas viande renseignés) : en moyenne 34 kgCO2e / français 
+    - les consommations de viande (en fonction du nombre de repas viande renseignés) : en moyenne 34 kgCO2e / français
     - les consommations de fruits, légumes, céréales et noix d'importation (à faire varier selon si l'on consomme local ou non) : en moyenne 86 kgCO2e / français, discriminées selon la part de local.
 
     Le reste des émissions liées à la déforestation importée liée à l'alimentation est attribué à chaque français de manière égale. Cela correspond à :
 
-    - la consommation d'huiles végétales : 5 kgCO2e / personne 
+    - la consommation d'huiles végétales : 5 kgCO2e / personne
     - la consommation d'autres produits non discriminables en fonction des régimes alimentaires : 76 kgCO2e / personne
 
 alimentation . déforestation . forfait moyen fruits céréales:
@@ -106,7 +106,7 @@ alimentation . plats:
   question: Choisissez les 14 repas (déjeuners et dîners) de votre semaine-type
   titre: Empreinte des repas
   description: |
-    Choisissez les plats qui représentent votre semaine type. 
+    Choisissez les plats qui représentent votre semaine type.
 
     A priori, vous en aurez 14 : 7 déjeuners et 7 dîners. Mais vous pouvez aussi manger moins, ou plus, c'est tout à fait possible !
 
@@ -120,8 +120,8 @@ alimentation . plats:
       - poisson gras
       - poisson blanc
   note: |
-    Pour le moment, nous proposons 6 repas types pour 6 régimes différents. Il a été choisi de limiter la granularité du modèle via 6 menus représentatifs 
-    des régimes associés pour simplifier l'estimation de l'empreinte du poste alimentation pour l'utilisateur 
+    Pour le moment, nous proposons 6 repas types pour 6 régimes différents. Il a été choisi de limiter la granularité du modèle via 6 menus représentatifs
+    des régimes associés pour simplifier l'estimation de l'empreinte du poste alimentation pour l'utilisateur
     (les spécificités de l'alimentation de chacun pourraient donner lieu à un simulateur complet dédié à l'alimentation).
 
     Ils ne sont pas directement basés sur les régimes de la Base Empreinte, [documentés par l'ADEME](https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?repas.htm), jugés obsolètes (peu exhaustifs, FE non issus d'Agribalyse).
@@ -401,7 +401,7 @@ alimentation . plats . viande rouge . déforestation:
   unité: kgCO2e/repas
   note: |
     L’étude [Pendril & al.](https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41) donne une empreinte moyenne de 34 kgCO2e / personne de déforestation importée liée à la consommation de viandes d'élevage.
-    Nous partons du principe que ces émissions liées à la production de viandes d'élevage appartiennent majoritairement à la catégorie "viande rouge" : c'est la catégorie la plus consommatrice de terres et de ressources. 
+    Nous partons du principe que ces émissions liées à la production de viandes d'élevage appartiennent majoritairement à la catégorie "viande rouge" : c'est la catégorie la plus consommatrice de terres et de ressources.
     La consommation moyenne par français de viande rouge se situe autour de 3 repas par semaine, soit 156 repas par an.
 
     En conséquence, nous ajoutons à l'empreinte des repas une empreinte moyenne de 0.218 kgCO2e / repas de viande rouge.
@@ -599,7 +599,7 @@ alimentation . petit déjeuner . continental:
 
 alimentation . petit déjeuner . continental . empreinte carbone:
   titre: Empreinte carbone d'un petit déjeuner continental
-  formule: 0.28
+  formule: 0.31
   unité: kgCO2e/repas
   description: |
     Petit déjeuner avec pain, viennoiserie, beurre, confiture et un fruit.
@@ -610,7 +610,7 @@ alimentation . petit déjeuner . continental . empreinte carbone:
 
 alimentation . petit déjeuner . continental . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner continental
-  formule: 1272
+  formule: 1215
   unité: l/repas
   description: |
     Petit déjeuner avec pain, viennoiserie, beurre, confiture et un fruit.
@@ -641,7 +641,7 @@ alimentation . petit déjeuner . lait vache céréales:
 
 alimentation . petit déjeuner . lait vache céréales . empreinte carbone:
   titre: Empreinte carbone d'un petit déjeuner avec lait de vache et céréales
-  formule: 0.460
+  formule: 0.45
   unité: kgCO2e/repas
   description: |
     Petit déjeuner avec un produit laitier (lait de vache) et une portion de céréales.
@@ -652,7 +652,7 @@ alimentation . petit déjeuner . lait vache céréales . empreinte carbone:
 
 alimentation . petit déjeuner . lait vache céréales . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner avec lait de vache et céréales
-  formule: 1404
+  formule: 379
   unité: l/repas
   description: |
     Petit déjeuner avec un produit laitier (lait de vache) et une portion de céréales.
@@ -683,7 +683,7 @@ alimentation . petit déjeuner . lait soja céréales . empreinte carbone:
 
 alimentation . petit déjeuner . lait soja céréales . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner avec lait de soja et céréales
-  formule: 1342
+  formule: 351
   unité: l/repas
   description: |
     Petit déjeuner avec un produit laitier (lait de soja) et une portion de céréales.
@@ -703,7 +703,7 @@ alimentation . petit déjeuner . lait avoine céréales:
 
 alimentation . petit déjeuner . lait avoine céréales . empreinte carbone:
   titre: Empreinte carbone d'un petit déjeuner avec lait de avoine et céréales
-  formule: 0.300
+  formule: 0.31
   unité: kgCO2e/repas
   description: |
     Petit déjeuner avec un produit laitier (lait d'avoine) et une portion de céréales.
@@ -714,7 +714,7 @@ alimentation . petit déjeuner . lait avoine céréales . empreinte carbone:
 
 alimentation . petit déjeuner . lait avoine céréales . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner avec lait de avoine et céréales
-  formule: 1386
+  formule: 390
   unité: l/repas
   description: |
     Petit déjeuner avec un produit laitier (lait d'avoine) et une portion de céréales.
@@ -734,7 +734,7 @@ alimentation . petit déjeuner . britannique:
 
 alimentation . petit déjeuner . britannique . empreinte carbone:
   titre: Empreinte carbone d'un petit déjeuner britannique
-  formule: 1.18
+  formule: 1.08
   unité: kgCO2e/repas
   description: |
     Petit déjeuner avec de la charcuterie, 2 œufs et des toasts.
@@ -745,7 +745,7 @@ alimentation . petit déjeuner . britannique . empreinte carbone:
 
 alimentation . petit déjeuner . britannique . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner britannique
-  formule: 1091
+  formule: 494
   unité: l/repas
   description: |
     Petit déjeuner avec de la charcuterie, 2 œufs et des toasts.
@@ -765,7 +765,7 @@ alimentation . petit déjeuner . végétalien:
 
 alimentation . petit déjeuner . végétalien . empreinte carbone:
   titre: Empreinte carbone d'un petit déjeuner végétalien
-  formule: 0.380
+  formule: 0.4
   unité: kgCO2e/repas
   description: |
     Petit déjeuner avec une portion de muesli, un fruit
@@ -776,7 +776,7 @@ alimentation . petit déjeuner . végétalien . empreinte carbone:
 
 alimentation . petit déjeuner . végétalien . empreinte eau:
   titre: Empreinte eau d'un petit déjeuner végétalien
-  formule: 1952
+  formule: 1015
   unité: l/repas
   description: |
     Petit déjeuner avec une portion de muesli, un fruit

--- a/data/alimentation/repas.publicodes
+++ b/data/alimentation/repas.publicodes
@@ -150,7 +150,7 @@ alimentation . plats . végétalien . empreinte:
 
 alimentation . plats . végétalien . empreinte carbone:
   titre: Empreinte carbone d'un repas végétalien
-  formule: 0.630
+  formule: 0.66
   unité: kgCO2e/repas
   note: |
     L'empreinte carbone d'un repas végétalien est donné par le tableau suivant :
@@ -172,7 +172,7 @@ alimentation . plats . végétalien . empreinte carbone:
 
 alimentation . plats . végétalien . empreinte eau:
   titre: Empreinte eau d'un repas végétalien
-  formule: 3610
+  formule: 1623
   unité: l/repas
   note: |
     L'empreinte eau d'un repas végétalien est donné par le tableau suivant :
@@ -215,7 +215,7 @@ alimentation . plats . végétarien . empreinte:
 
 alimentation . plats . végétarien . empreinte carbone:
   titre: Empreinte carbone d'un repas végétarien
-  formule: 1.11
+  formule: 0.97
   unité: kgCO2e/repas
   note: |
     L'empreinte carbone d'un repas végétarien est donné par le tableau suivant :
@@ -237,7 +237,7 @@ alimentation . plats . végétarien . empreinte carbone:
 
 alimentation . plats . végétarien . empreinte eau:
   titre: Empreinte eau d'un repas végétarien
-  formule: 3546
+  formule: 1466
   unité: l/repas
   note: |
     L'empreinte eau d'un repas végétarien est donné par le tableau suivant :
@@ -279,7 +279,7 @@ alimentation . plats . viande blanche . empreinte:
 
 alimentation . plats . viande blanche . empreinte carbone:
   titre: Empreinte carbone d'un repas de type viande blanche (poulet, porc)
-  formule: 1.94
+  formule: 1.75
   unité: kgCO2e/repas
   note: |
     L'empreinte carbone d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
@@ -301,7 +301,7 @@ alimentation . plats . viande blanche . empreinte carbone:
 
 alimentation . plats . viande blanche . empreinte eau:
   titre: Empreinte eau d'un repas de type viande blanche (poulet, porc, fromage)
-  formule: 4010
+  formule: 1852
   unité: l/repas
   note: |
     L'empreinte eau d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
@@ -346,7 +346,7 @@ alimentation . plats . viande rouge . empreinte carbone:
   titre: Empreinte carbone d'un repas de type viande rouge (bœuf, veau, agneau)
   formule:
     somme:
-      - 4.79
+      - 5.19
       - déforestation
   unité: kgCO2e/repas
   note: |
@@ -372,7 +372,7 @@ alimentation . plats . viande rouge . empreinte carbone:
 
 alimentation . plats . viande rouge . empreinte eau:
   titre: Empreinte eau d'un repas de type viande rouge (bœuf, veau, agneau)
-  formule: 4014
+  formule: 2017
   unité: l/repas
   description: |
     L'empreinte eau d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
@@ -429,7 +429,7 @@ alimentation . plats . poisson gras . empreinte:
 
 alimentation . plats . poisson gras . empreinte carbone:
   titre: Empreinte carbone d'un repas de type poisson gras (thon, saumon, sardine, maquereau)
-  formule: 1.31
+  formule: 1.21
   unité: kgCO2e/repas
   description: |
     L'empreinte carbone d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
@@ -451,7 +451,7 @@ alimentation . plats . poisson gras . empreinte carbone:
 
 alimentation . plats . poisson gras . empreinte eau:
   titre: Empreinte eau d'un repas de type poisson gras (thon, saumon, sardine, maquereau)
-  formule: 3679
+  formule: 2031
   unité: l/repas
   description: |
     L'empreinte eau d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
@@ -494,7 +494,7 @@ alimentation . plats . poisson blanc . empreinte:
 
 alimentation . plats . poisson blanc . empreinte carbone:
   titre: Empreinte carbone d'un repas de type poisson blanc
-  formule: 2.14
+  formule: 2.29
   unité: kgCO2e/repas
   description: |
     L'empreinte carbone d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
@@ -516,7 +516,7 @@ alimentation . plats . poisson blanc . empreinte carbone:
 
 alimentation . plats . poisson blanc . empreinte eau:
   titre: Empreinte eau d'un repas de type poisson blanc
-  formule: 3115
+  formule: 1422
   unité: l/repas
   description: |
     L'empreinte eau d'un repas à dominate "poisson blanc" est donné par le tableau suivant :

--- a/data/alimentation/repas.publicodes
+++ b/data/alimentation/repas.publicodes
@@ -153,18 +153,7 @@ alimentation . plats . végétalien . empreinte carbone:
   formule: 0.66
   unité: kgCO2e/repas
   note: |
-    L'empreinte carbone d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,66      |  0,07    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 0,98      |  0,01    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 0,73      |  0,15    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **0,63** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -175,18 +164,7 @@ alimentation . plats . végétalien . empreinte eau:
   formule: 1623
   unité: l/repas
   note: |
-    L'empreinte eau d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,23      |  23,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 7,81      |  1561    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **3610** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -218,18 +196,7 @@ alimentation . plats . végétarien . empreinte carbone:
   formule: 0.97
   unité: kgCO2e/repas
   note: |
-    L'empreinte carbone d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |       |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 3,17      |  0,38    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **1,11** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -240,18 +207,7 @@ alimentation . plats . végétarien . empreinte eau:
   formule: 1466
   unité: l/repas
   note: |
-    L'empreinte eau d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 4,37      |  524     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **3546** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -282,18 +238,7 @@ alimentation . plats . viande blanche . empreinte carbone:
   formule: 1.75
   unité: kgCO2e/repas
   note: |
-    L'empreinte carbone d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 8,03      |  1,21    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **1,94** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -304,18 +249,7 @@ alimentation . plats . viande blanche . empreinte eau:
   formule: 1852
   unité: l/repas
   note: |
-    L'empreinte eau d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 6,59     |  988      |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |       **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **4010** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -350,18 +284,7 @@ alimentation . plats . viande rouge . empreinte carbone:
       - déforestation
   unité: kgCO2e/repas
   note: |
-    L'empreinte carbone d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 27,08     |  4,06    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **4,79** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -375,18 +298,7 @@ alimentation . plats . viande rouge . empreinte eau:
   formule: 2017
   unité: l/repas
   description: |
-    L'empreinte eau d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 6,01      |  902     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **3923** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -432,18 +344,7 @@ alimentation . plats . poisson gras . empreinte carbone:
   formule: 1.21
   unité: kgCO2e/repas
   description: |
-    L'empreinte carbone d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 3,85      |  0,58    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -454,18 +355,7 @@ alimentation . plats . poisson gras . empreinte eau:
   formule: 2031
   unité: l/repas
   description: |
-    L'empreinte eau d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 4,38      |  657     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **3679** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -497,18 +387,7 @@ alimentation . plats . poisson blanc . empreinte carbone:
   formule: 2.29
   unité: kgCO2e/repas
   description: |
-    L'empreinte carbone d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 9,36      |  1,4     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -519,18 +398,7 @@ alimentation . plats . poisson blanc . empreinte eau:
   formule: 1422
   unité: l/repas
   description: |
-    L'empreinte eau d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 0,63      |  94,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **3115** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 

--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -14680,23 +14680,28 @@ logement . construction:
   titre.lock: construction
 logement . empreinte chauffage air:
   description: |
-    For every kWh of each type of energy, how much of it is used to heat the air in a home?
+    For each kWh of each type of energy, how much is used to heat the air in a home?
 
-    > We use here <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">the CEREN data</a>
-    via the work done in the file <a href="https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes">chiffres parc logements français.publicodes</a>.
+    > We are using <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">data from CEREN</a>
+    via the work carried out in the file <a href="https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes">chiffres parc logements français.publicodes</a>.
   description.auto: |
-    For every kWh of each type of energy, how much of it is used to heat the air in a home?
+    For each kWh of each type of energy, how much is used to heat the air in a home?
 
-    > We use here <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">the data of CEREN</a>
-    we use here the data of CEREN via the work done in the file <a href="https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.yaml">figures French housing stock.publicodes</a>.
+    > We are using <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">data from CEREN</a>
+    via the work carried out in the file <a href="https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes">chiffres parc logements français.publicodes</a>.
   description.lock: |
     Pour chaque kWh de chaque type d'énergie, quelle est la part utilisée pour le chauffage de l'air d'un foyer ?
 
-    > Nous utilions ici [les données du CEREN](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel)
+    > Nous utilisons ici [les données du CEREN](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel)
     via le travail réalisé dans le fichier [chiffres parc logements français.publicodes](https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes).
   titre: footprint heating air
   titre.auto: footprint heating air
   titre.lock: empreinte chauffage air
+  description.previous_review: |
+    For every kWh of each type of energy, how much of it is used to heat the air in a home?
+
+    > We use here <a href="https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel">the CEREN data</a>
+    via the work done in the file <a href="https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes">chiffres parc logements français.publicodes</a>.
 logement . empreinte chauffage air utilisateur:
   titre: footprint heating user air
   titre.auto: footprint heating user air
@@ -26547,7 +26552,7 @@ alimentation . repas . poisson faible empreinte . différence par semaine . nouv
   titre: compensation for oily fish
   titre.auto: compensation for oily fish
   titre.lock: compensation poisson gras
-  description: We compensate for the elimination of white fish dishes with fatty fish dishes.
+  description: We compensate for the elimination of white fish dishes with oily fish dishes.
   description.auto: We compensate for the elimination of white fish dishes with fatty fish dishes.
   description.lock: On compense la suppression des plats poisson blanc en plat poisson gras.
 alimentation . plats . viande blanche . nombre:
@@ -29383,52 +29388,19 @@ alimentation . plats . viande rouge . empreinte eau:
   titre.auto: Water footprint of a red meat meal (beef, veal, lamb)
   titre.lock: Empreinte eau d'un repas de type viande rouge (bœuf, veau, agneau)
   description: |
-    The water footprint of a meal dominated by red meat (beef, veal, lamb, etc.) is given in the table below:
+    Meal containing 150g of an average red meat (based on consolidation of average red meat consumption from the INCA3 study), an average side dish (based on average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | Red meat | VR | 150 | 209,58 | 30,15 | 9,82 | 6,01 | 902 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 775.08 | 55.37 | 30.44 | **3923** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.auto: |
-    The water footprint of a meal dominated by red meat (beef, veal, lamb, etc.) is given in the table below:
+    Meal containing 150g of an average red meat (based on consolidation of average red meat consumption from the INCA3 study), an average side dish (based on average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | Red meat | VR | 150 | 209,58 | 30,15 | 9,82 | 6,01 | 902 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 775.08 | 55.37 | 30.44 | **3923** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 6,01      |  902     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **3923** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -29543,52 +29515,19 @@ alimentation . plats . végétarien . empreinte carbone:
   titre.auto: Carbon footprint of a vegetarian meal
   titre.lock: Empreinte carbone d'un repas végétarien
   note: |
-    The carbon footprint of a vegetarian meal is given in the table below:
+    Meals containing eggs, an "average" side dish (derived from consolidation work on average French consumption averages taken from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | 2 eggs | 22000 | 120 | 168 | 15,24 | 11,8 | 3,17 | 0,38 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 675 | 733.5 | 40.46 | 32.42 | **1.11** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The carbon footprint of a vegetarian meal is given in the table below:
+    Meals containing eggs, an "average" side dish (derived from consolidation work on average French consumption averages taken from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | 2 eggs | 22000 | 120 | 168 | 15,24 | 11,8 | 3,17 | 0,38 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 675 | 733.5 | 40.46 | 32.42 | **1.11** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte carbone d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |       |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 3,17      |  0,38    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **1,11** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -29895,104 +29834,38 @@ alimentation . plats . végétalien . empreinte carbone:
   titre.auto: Carbon footprint of a vegan meal
   titre.lock: Empreinte carbone d'un repas végétalien
   note: |
-    The carbon footprint of a vegan meal is given in the table below:
+    Meal containing tofu, an "average" side dish (based on average French consumption averages from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | Tofu plain, prepackaged | 20904 | 100 | 143 | 13.4 | 8.5 | 0.66 | 0.07 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | 17270 | 7 | 63 | 0 | 6,99 | 0,98 | 0,01 | Extra virgin olive oil
-    | **Dessert** | | | | | | | |
-    | Dessert vegan | DV | 200 | 118.7 | 1.42 | 0.29 | 0.73 | 0.15 |
-    | Bread 7001 | 50 | 142 | 4,14 | 0,7 | 0,69 | 0,03 |
-    | Total | 657 | 658.81 | 34.68 | 19.3 | **0.63** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The carbon footprint of a vegan meal is given in the table below:
+    Meal containing tofu, an "average" side dish (based on average French consumption averages from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | Tofu plain, prepackaged | 20904 | 100 | 143 | 13.4 | 8.5 | 0.66 | 0.07 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | 17270 | 7 | 63 | 0 | 6,99 | 0,98 | 0,01 | Extra virgin olive oil
-    | **Dessert** | | | | | | | |
-    | Dessert vegan | DV | 200 | 118.7 | 1.42 | 0.29 | 0.73 | 0.15 |
-    | Bread 7001 | 50 | 142 | 4,14 | 0,7 | 0,69 | 0,03 |
-    | Total | 657 | 658.81 | 34.68 | 19.3 | **0.63** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte carbone d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,66      |  0,07    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 0,98      |  0,01    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 0,73      |  0,15    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **0,63** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
     🧮 Le calcul détaillé est [disponible ici](https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355) sous forme de tableur.
 alimentation . plats . végétalien . empreinte eau:
   note: |
-    The water footprint of a vegan meal is given in the table below:
+    Meal containing tofu, an "average" side dish (based on average French consumption averages from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | | | | | |
-    | Tofu plain, pre-packaged | 20904 | 100 | 143 | 13.4 | 8.5 | 0.23 | 23.0 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | 17270 | 7 | 63 | 0 | 6,99 | 22,0 | 154,3 | Extra virgin olive oil
-    | **Dessert** | | | | | | | |
-    | Vegan dessert | DV | 200 | 118.7 | 1.42 | 0.29 | 7.81 | 1561 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 657 | 658,81 | 34,68 | 19,3 | **3610** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The water footprint of a vegan meal is given in the table below:
+    Meal containing tofu, an "average" side dish (based on average French consumption averages from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | | | | | |
-    | Tofu plain, pre-packaged | 20904 | 100 | 143 | 13.4 | 8.5 | 0.23 | 23.0 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | 17270 | 7 | 63 | 0 | 6,99 | 22,0 | 154,3 | Extra virgin olive oil
-    | **Dessert** | | | | | | | |
-    | Vegan dessert | DV | 200 | 118.7 | 1.42 | 0.29 | 7.81 | 1561 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 657 | 658,81 | 34,68 | 19,3 | **3610** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte eau d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,23      |  23,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 7,81      |  1561    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **3610** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30027,52 +29900,19 @@ bilan . par jour:
   titre.lock: par jour
 alimentation . plats . viande blanche . empreinte carbone:
   note: |
-    The carbon footprint of a meal dominated by "white meat" (poultry, pork, etc.) is given in the table below:
+    Meal containing 150g of an average white meat (based on the average consumption of white meat in the INCA3 study), an average side dish (based on the average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | White meat | VB | 150 | 205,06 | 31,27 | 8,31 | 8,03 | 1,21 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 770,56 | 56,49 | 28,94 | | **1,94** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The carbon footprint of a meal dominated by "white meat" (poultry, pork, etc.) is given in the table below:
+    Meal containing 150g of an average white meat (based on the average consumption of white meat in the INCA3 study), an average side dish (based on the average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | White meat | VB | 150 | 205,06 | 31,27 | 8,31 | 8,03 | 1,21 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 770,56 | 56,49 | 28,94 | | **1,94** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte carbone d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 8,03      |  1,21    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **1,94** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30194,52 +30034,19 @@ alimentation . petit déjeuner . continental . empreinte eau:
     🧮 Le calcul détaillé est [disponible ici](https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355) sous forme de tableur.
 alimentation . plats . végétarien . empreinte eau:
   note: |
-    The water footprint of a vegetarian meal is given in the table below:
+    Meals containing eggs, an "average" side dish (derived from consolidation work on average French consumption averages taken from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Proteins (g) | Lipids (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | 2 eggs | 22000 | 120 | 168 | 15,24 | 11,8 | 4,37 | 524 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,0 | 154,3 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread | 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 675 | 733,5 | 40,46 | 32,42 | **3546** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The water footprint of a vegetarian meal is given in the table below:
+    Meals containing eggs, an "average" side dish (derived from consolidation work on average French consumption averages taken from the INCA3 study for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Proteins (g) | Lipids (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | 2 eggs | 22000 | 120 | 168 | 15,24 | 11,8 | 4,37 | 524 |
-    | Medium side dish | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,0 | 154,3 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread | 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 675 | 733,5 | 40,46 | 32,42 | **3546** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte eau d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 4,37      |  524     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **3546** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30307,52 +30114,19 @@ acv numerique . acv . console de salon . eau . fabrication:
   description.lock: '> ℹ️ Cette règle provient du modèle [`@incubateur-ademe/publicodes-acv-numerique`](https://github.com/incubateur-ademe/publicodes-acv-numerique).'
 alimentation . plats . poisson blanc . empreinte carbone:
   description: |
-    The carbon footprint of a meal dominated by "white fish" is given in the table below:
+    Meal containing 150g of an average white fish (from consolidation work on average consumption of white fish from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | |
-    | White fish | PB | 150 | 127,71 | 27,81 | 1,82 | 9,36 | 1,4 |
-    | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 693.21 | 53.03 | 22.44 | **2.14** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.auto: |
-    The carbon footprint of a meal dominated by "white fish" is given in the table below:
+    Meal containing 150g of an average white fish (from consolidation work on average consumption of white fish from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | |
-    | White fish | PB | 150 | 127,71 | 27,81 | 1,82 | 9,36 | 1,4 |
-    | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 693.21 | 53.03 | 22.44 | **2.14** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.lock: |
-    L'empreinte carbone d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 9,36      |  1,4     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30376,52 +30150,19 @@ alimentation . plats . viande blanche . empreinte eau:
   titre.auto: Water footprint of a white meat meal (chicken, pork, cheese)
   titre.lock: Empreinte eau d'un repas de type viande blanche (poulet, porc, fromage)
   note: |
-    The water footprint of a meal dominated by "white meat" (poultry, pork, etc.) is given in the following table:
+    Meal containing 150g of an average white meat (based on the average consumption of white meat in the INCA3 study), an average side dish (based on the average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | White meat | VB | 150 | 205,06 | 31,27 | 8,31 | 6,59 | 988 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,0 | 154,3 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 770.56 | 56.49 | 28.94 | | **4010** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.auto: |
-    The water footprint of a meal dominated by "white meat" (poultry, pork, etc.) is given in the following table:
+    Meal containing 150g of an average white meat (based on the average consumption of white meat in the INCA3 study), an average side dish (based on the average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | White meat | VB | 150 | 205,06 | 31,27 | 8,31 | 6,59 | 988 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1855 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,0 | 154,3 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 770.56 | 56.49 | 28.94 | | **4010** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   note.lock: |
-    L'empreinte eau d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 6,59     |  988      |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |       **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **4010** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30873,52 +30614,19 @@ logement . eau domestique . jardin . type arrosage:
   question.lock: En général, comment arrosez-vous votre jardin ?
 alimentation . plats . poisson blanc . empreinte eau:
   description: |
-    The water footprint of a meal dominated by "white fish" is given in the table below:
+    Meal containing 150g of an average white fish (from consolidation work on average consumption of white fish from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | PB | 150 | 127,71 | 27,81 | 1,82 | 0,63 | 94,0 | White fish
-    | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread | 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 584.02 | 48.93 | 10.33 | **3115** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.auto: |
-    The water footprint of a meal dominated by "white fish" is given in the table below:
+    Meal containing 150g of an average white fish (from consolidation work on average consumption of white fish from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | PB | 150 | 127,71 | 27,81 | 1,82 | 0,63 | 94,0 | White fish
-    | Medium accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread | 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 584.02 | 48.93 | 10.33 | **3115** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 0,63      |  94,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **3115** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30950,52 +30658,19 @@ alimentation . boisson . alcool . facteur cocktail carbone:
   note.lock: Facteur d'émission issu d'[Agribalyse, cocktail base rhum](https://agribalyse.ademe.fr/app/aliments/1012#Cocktail_%C3%A0_base_de_rhum), 0.91 kgCO2e/kg. On considère que la masse volumique d'un cocktail est de 1kg/l.
 alimentation . plats . poisson gras . empreinte eau:
   description: |
-    The water footprint of a meal dominated by "oily fish" (tuna, salmon, sardines, mackerel, etc.) is given in the following table:
+    Meal containing 150g of an average fatty fish (from consolidation work on average fatty fish consumption from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 4,38 | 657 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 746,57 | 54,28 | 25,67 | **3679** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.auto: |
-    The water footprint of a meal dominated by "oily fish" (tuna, salmon, sardines, mackerel, etc.) is given in the following table:
+    Meal containing 150g of an average fatty fish (from consolidation work on average fatty fish consumption from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, pulses, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | |
-    | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 4,38 | 657 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 6,19 | 1856 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 22,04 | 110 |
-    | **Dessert** | | | | | | | |
-    | Dessert medium | DE | 200 | 186.39 | 5.36 | 12.11 | 5.20 | 1041 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.29 | 14.5 |
-    | Total | 705 | 746,57 | 54,28 | 25,67 | **3679** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 4,38      |  657     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **3679** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -31135,52 +30810,19 @@ divers . textile . t-shirt . empreinte eau:
   titre.lock: empreinte eau
 alimentation . plats . poisson gras . empreinte carbone:
   description: |
-    The carbon footprint of a meal dominated by "oily fish" (tuna, salmon, sardines, mackerel, etc.) is given in the table below:
+    Meal containing 150g of an average oily fish (from consolidation work on average fatty fish consumption from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, legumes, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 3,85 | 0,58 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 855,77 | 58,38 | 37,79 | **1,31** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.auto: |
-    The carbon footprint of a meal dominated by "oily fish" (tuna, salmon, sardines, mackerel, etc.) is given in the table below:
+    Meal containing 150g of an average fatty fish (from consolidation work on average fatty fish consumption from the INCA3 study), an average side dish (consolidation on average consumption for vegetables, legumes, rice, cereals and pasta), oil.
 
-    | Ingredients | CIQUAL | Qty (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | |
-    | Fatty fish | PG | 150 | 290,27 | 33,16 | 17,16 | 3,85 | 0,58 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 855,77 | 58,38 | 37,79 | **1,31** |
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
-
-    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> as a spreadsheet.
+    🧮 The detailed calculation is <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">available here</a> in spreadsheet form.
   description.lock: |
-    L'empreinte carbone d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 3,85      |  0,58    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -31396,58 +31038,25 @@ alimentation . plats . viande rouge . empreinte carbone:
   titre.auto: Carbon footprint of a red meat meal (beef, veal, lamb)
   titre.lock: Empreinte carbone d'un repas de type viande rouge (bœuf, veau, agneau)
   note: |
-    The carbon footprint of a meal dominated by red meat (beef, veal, lamb, etc.) is given in the table below:
+    Meal containing 150g of an average red meat (based on consolidation of average red meat consumption from the INCA3 study), an average side dish (based on average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | Red Meat | VR | 150 | 209,58 | 30,15 | 9,82 | 27,08 | 4,06 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 775.08 | 55.37 | 30.44 | **4.79** |
-
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
     As far as deforestation is concerned, our food causes deforestation abroad, which has a significant carbon impact. This footprint is not included in the Agribalyse emission factors.
 
-    According to the <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al</a>. study, part of this deforestation is specifically associated with the consumption of farmed meat.
+    According to the <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al.</a> study, part of this deforestation is specifically associated with the consumption of farmed meat.
     We consider that this share associated with "farmed meat" is mainly associated with the consumption of red meat, which is why we add this share of deforestation to red meat meals.
   note.auto: |
-    The carbon footprint of a meal dominated by red meat (beef, veal, lamb, etc.) is given in the table below:
+    Meal containing 150g of an average red meat (based on consolidation of average red meat consumption from the INCA3 study), an average side dish (based on average consumption of vegetables, pulses, rice, cereals and pasta) and oil.
 
-    | CIQUAL | Qte (g) | Kcal | Protein (g) | Fat (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | |
-    | Red Meat | VR | 150 | 209,58 | 30,15 | 9,82 | 27,08 | 4,06 |
-    | Medium Accompaniment | AM | 300 | 192,11 | 15,72 | 2,81 | 1,26 | 0,38 |
-    | Extra virgin olive oil | 17270 | 5 | 45 | 0 | 5 | 0,98 | 0 |
-    | **Dessert** | | | | | | | | |
-    | Average dessert | DE | 200 | 186.39 | 5.36 | 12.11 | 1.57 | 0.31 |
-    | Bread 7001 | 50 | 142 | 4.14 | 0.7 | 0.69 | 0.03 |
-    | Total | 705 | 775.08 | 55.37 | 30.44 | **4.79** |
-
-    💡 Full documentation can be found in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
+    💡 You can find the full documentation in <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">our wiki</a>.
 
     As far as deforestation is concerned, our food causes deforestation abroad, which has a significant carbon impact. This footprint is not included in the Agribalyse emission factors.
 
-    According to the <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al</a>. study, part of this deforestation is specifically associated with the consumption of farmed meat.
+    According to the <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al.</a> study, part of this deforestation is specifically associated with the consumption of farmed meat.
     We consider that this share associated with "farmed meat" is mainly associated with the consumption of red meat, which is why we add this share of deforestation to red meat meals.
   note.lock: |
-    L'empreinte carbone d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 27,08     |  4,06    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **4,79** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 

--- a/data/i18n/t9n/translated-rules-es.yaml
+++ b/data/i18n/t9n/translated-rules-es.yaml
@@ -16719,7 +16719,7 @@ logement . empreinte chauffage air:
   description.lock: |
     Pour chaque kWh de chaque type d'énergie, quelle est la part utilisée pour le chauffage de l'air d'un foyer ?
 
-    > Nous utilions ici [les données du CEREN](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel)
+    > Nous utilisons ici [les données du CEREN](https://www.statistiques.developpement-durable.gouv.fr/consommation-denergie-par-usage-du-residentiel)
     via le travail réalisé dans le fichier [chiffres parc logements français.publicodes](https://github.com/incubateur-ademe/nosgestesclimat/blob/master/data/logement/chiffres%20parc%20logements%20fran%C3%A7ais.publicodes).
 logement . chauffage . baisse température:
   description: |
@@ -29302,52 +29302,19 @@ alimentation . plats . végétarien . empreinte carbone:
   titre.auto: Huella de carbono de una comida vegetariana
   titre.lock: Empreinte carbone d'un repas végétarien
   note: |
-    En la tabla siguiente se indica la huella de carbono de una comida vegetariana:
+    Comidas que contienen huevos, una guarnición "media" (derivada de los trabajos de consolidación sobre las medias de consumo francesas extraídas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | 2 huevos 22000 120 168 15,24 11,8 3,17 0,38
-    | Guarnición mediana AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total 675 733,5 40,46 32,42 1,11
+    💡 Puede encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    En la tabla siguiente se indica la huella de carbono de una comida vegetariana:
+    Comidas que contienen huevos, una guarnición "media" (derivada de los trabajos de consolidación sobre las medias de consumo francesas extraídas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | 2 huevos 22000 120 168 15,24 11,8 3,17 0,38
-    | Guarnición mediana AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total 675 733,5 40,46 32,42 1,11
+    💡 Puede encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte carbone d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |       |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 3,17      |  0,38    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **1,11** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -29365,52 +29332,19 @@ alimentation . plats . poisson blanc . empreinte carbone:
   titre.auto: Huella de carbono de una harina de pescado blanco
   titre.lock: Empreinte carbone d'un repas de type poisson blanc
   description: |
-    La huella de carbono de una comida en la que predomina el "pescado blanco" figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado blanco medio (a partir del trabajo de consolidación sobre el consumo medio de pescado blanco del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | |
-    | Pescado blanco PB 150 127,71 27,81 1,82 9,36 1,4
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 693,21, 53,03, 22,44, **2,14**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.auto: |
-    La huella de carbono de una comida en la que predomina el "pescado blanco" figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado blanco medio (a partir del trabajo de consolidación sobre el consumo medio de pescado blanco del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | |
-    | Pescado blanco PB 150 127,71 27,81 1,82 9,36 1,4
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 693,21, 53,03, 22,44, **2,14**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.lock: |
-    L'empreinte carbone d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 9,36      |  1,4     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 693,21 | 53,03         | 22,44       |           | **2,14** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -29681,52 +29615,19 @@ alimentation . plats . viande blanche . empreinte carbone:
   titre.auto: Huella de carbono de una comida de carne blanca (pollo, cerdo)
   titre.lock: Empreinte carbone d'un repas de type viande blanche (poulet, porc)
   note: |
-    La huella de carbono de una comida en la que predomine la "carne blanca" (aves de corral, cerdo, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de una carne blanca media (basada en el consumo medio de carne blanca en el estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Carne blanca VB 150 205,06 31,27 8,31 8,03 1,21
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 770,56, 56,49, 28,94
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    La huella de carbono de una comida en la que predomine la "carne blanca" (aves de corral, cerdo, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de una carne blanca media (basada en el consumo medio de carne blanca en el estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Carne blanca VB 150 205,06 31,27 8,31 8,03 1,21
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 770,56, 56,49, 28,94
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte carbone d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 8,03      |  1,21    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **1,94** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -29940,52 +29841,19 @@ alimentation . plats . végétalien . empreinte carbone:
   titre.auto: Huella de carbono de una comida vegana
   titre.lock: Empreinte carbone d'un repas végétalien
   note: |
-    En la tabla siguiente se indica la huella de carbono de una comida vegana:
+    Comida que contiene tofu, una guarnición "media" (basada en las medias de consumo francesas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Tofu natural, preenvasado 20904 100 143 13,4 8,5 0,66 0,07
-    | Plato mediano de acompañamiento AM 300 192,11 15,72 2,81 1,26 0,38
-    | 17270 | 7 | 63 | 0 | 6,99 | 0,98 | 0,01 | Aceite de oliva virgen extra
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre vegano DV 200 118,7 1,42 0,29 0,73 0,15
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total 657 658,81 34,68 19,3 0,63
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    En la tabla siguiente se indica la huella de carbono de una comida vegana:
+    Comida que contiene tofu, una guarnición "media" (basada en las medias de consumo francesas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Tofu natural, preenvasado 20904 100 143 13,4 8,5 0,66 0,07
-    | Plato mediano de acompañamiento AM 300 192,11 15,72 2,81 1,26 0,38
-    | 17270 | 7 | 63 | 0 | 6,99 | 0,98 | 0,01 | Aceite de oliva virgen extra
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre vegano DV 200 118,7 1,42 0,29 0,73 0,15
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total 657 658,81 34,68 19,3 0,63
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte carbone d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,66      |  0,07    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 0,98      |  0,01    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 0,73      |  0,15    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **0,63** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30187,52 +30055,19 @@ alimentation . plats . viande blanche . empreinte eau:
   titre.auto: Huella hídrica de una comida de carne blanca (pollo, cerdo, queso)
   titre.lock: Empreinte eau d'un repas de type viande blanche (poulet, porc, fromage)
   note: |
-    La huella hídrica de una comida en la que predomine la "carne blanca" (aves de corral, cerdo, etc.) se indica en el cuadro siguiente:
+    Comida que contiene 150 g de una carne blanca media (basada en el consumo medio de carne blanca en el estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | Carne blanca VB 150 205,06 31,27 8,31 6,59 988
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1855
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,0 154,3
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total | 705 | 770.56 | 56.49 | 28.94 | | **4010** |
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    La huella hídrica de una comida en la que predomine la "carne blanca" (aves de corral, cerdo, etc.) se indica en el cuadro siguiente:
+    Comida que contiene 150 g de una carne blanca media (basada en el consumo medio de carne blanca en el estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | Carne blanca VB 150 205,06 31,27 8,31 6,59 988
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1855
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,0 154,3
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total | 705 | 770.56 | 56.49 | 28.94 | | **4010** |
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte eau d'un repas à dominate "viande blanche" (volaille, porc...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande blanche              | VB     | 150     | 205,06 | 31,27         | 8,31        | 6,59     |  988      |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |       **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 770,56 | 56,49         | 28,94       |           | **4010** |
+    Repas contenant 150g d'une viande blanche moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande blanche de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30264,52 +30099,19 @@ alimentation . plats . viande rouge . empreinte eau:
   titre.auto: Huella hídrica de una comida de carne roja (ternera, buey, cordero)
   titre.lock: Empreinte eau d'un repas de type viande rouge (bœuf, veau, agneau)
   description: |
-    La huella hídrica de una comida en la que predomine la carne roja (ternera, buey, cordero, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de una carne roja media (basada en la consolidación del consumo medio de carne roja del estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Carne roja VR 150 209,58 30,15 9,82 6,01 902
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 705, 775,08, 55,37, 30,44, **3923**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.auto: |
-    La huella hídrica de una comida en la que predomine la carne roja (ternera, buey, cordero, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de una carne roja media (basada en la consolidación del consumo medio de carne roja del estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Carne roja VR 150 209,58 30,15 9,82 6,01 902
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 705, 775,08, 55,37, 30,44, **3923**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 6,01      |  902     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **3923** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30326,52 +30128,19 @@ alimentation . plats . végétalien . empreinte eau:
   titre.auto: Huella hídrica de una comida vegana
   titre.lock: Empreinte eau d'un repas végétalien
   note: |
-    En la tabla siguiente se indica la huella hídrica de una comida vegana:
+    Comida que contiene tofu, una guarnición "media" (basada en las medias de consumo francesas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteína (g) | Grasa (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Tofu natural, preenvasado 20904 100 143 13,4 8,5 0,23 23,0
-    | Plato mediano de acompañamiento AM 300 192,11 15,72 2,81 6,19 1855
-    | 17270 | 7 | 63 | 0 | 6,99 | 22,0 | 154,3 | Aceite de oliva virgen extra
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre vegano DV 200 118,7 1,42 0,29 7,81 1561
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 657, 658,81, 34,68, 19,3, **3610**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    En la tabla siguiente se indica la huella hídrica de una comida vegana:
+    Comida que contiene tofu, una guarnición "media" (basada en las medias de consumo francesas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteína (g) | Grasa (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Tofu natural, preenvasado 20904 100 143 13,4 8,5 0,23 23,0
-    | Plato mediano de acompañamiento AM 300 192,11 15,72 2,81 6,19 1855
-    | 17270 | 7 | 63 | 0 | 6,99 | 22,0 | 154,3 | Aceite de oliva virgen extra
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre vegano DV 200 118,7 1,42 0,29 7,81 1561
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 657, 658,81, 34,68, 19,3, **3610**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte eau d'un repas végétalien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Tofu nature, préemballé     | 20904  | 100     | 143    | 13,4          | 8,5         | 0,23      |  23,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 7       | 63     | 0             | 6,99        | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert vegan               | DV     | 200     | 118,7  | 1,42          | 0,29        | 7,81      |  1561    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 657     | 658,81 | 34,68         | 19,3        |           | **3610** |
+    Repas contenant du tofu, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30521,52 +30290,19 @@ alimentation . boisson . alcool . facteur vin carbone:
   titre.lock: facteur vin carbone
 alimentation . plats . végétarien . empreinte eau:
   note: |
-    La huella hídrica de una comida vegetariana se indica en la tabla siguiente:
+    Comidas que contienen huevos, una guarnición "media" (derivada de los trabajos de consolidación sobre las medias de consumo francés tomadas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Lípidos (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | | |
-    | 2 huevos 22000 120 168 15,24 11,8 4,37 524
-    | Guarnición mediana AM 300 192,11 15,72 2,81 6,19 1855
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,0 154,3
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 675, 733,5, 40,46, 32,42, **3546**
+    💡 Puede encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.auto: |
-    La huella hídrica de una comida vegetariana se indica en la tabla siguiente:
+    Comidas que contienen huevos, una guarnición "media" (derivada de los trabajos de consolidación sobre las medias de consumo francés tomadas del estudio INCA3 para verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Lípidos (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | | |
-    | 2 huevos 22000 120 168 15,24 11,8 4,37 524
-    | Guarnición mediana AM 300 192,11 15,72 2,81 6,19 1855
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,0 154,3
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 675, 733,5, 40,46, 32,42, **3546**
+    💡 Puede encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   note.lock: |
-    L'empreinte eau d'un repas végétarien est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | 2 œufs                      | 22000  | 120     | 168    | 15,24         | 11,8        | 4,37      |  524     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1855    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,0      |  154,3   |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 675     | 733,5  | 40,46         | 32,42       |           | **3546** |
+    Repas contenant des œufs, un accompagnement "moyen" (issu d'un travail de consolidation sur les moyennes de consommation des français tirées de l'étude INCA3 pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30592,52 +30328,19 @@ services sociétaux . fuites réseau:
   titre.lock: Fuites du réseau d'eau potable
 alimentation . plats . poisson gras . empreinte eau:
   description: |
-    La huella hídrica de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en la siguiente tabla:
+    Comida que contiene 150 g de un pescado azul medio (a partir del trabajo de consolidación sobre el consumo medio de pescado azul del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Qte (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | Pescado graso PG 150 290,27 33,16 17,16 4,38 657
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total | 705 | 746,57 | 54,28 | 25,67 | **3679** | |
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.auto: |
-    La huella hídrica de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) se indica en la siguiente tabla:
+    Comida que contiene 150 g de un pescado azul medio (a partir del trabajo de consolidación sobre el consumo medio de pescado azul del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Qte (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | Pescado graso PG 150 290,27 33,16 17,16 4,38 657
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total | 705 | 746,57 | 54,28 | 25,67 | **3679** | |
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 4,38      |  657     |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 746,57 | 54,28         | 25,67       |           | **3679** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30799,52 +30502,19 @@ alimentation . plats . poisson blanc . empreinte eau:
   titre.auto: Huella hídrica de una harina de pescado blanco
   titre.lock: Empreinte eau d'un repas de type poisson blanc
   description: |
-    La huella hídrica de una comida en la que predomina el "pescado blanco" figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado blanco medio (a partir del trabajo de consolidación sobre el consumo medio de pescado blanco del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | PB | 150 | 127,71 | 27,81 | 1,82 | 0,63 | 94,0 | Pescado blanco
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 705, 584,02, 48,93, 10,33, **3115**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.auto: |
-    La huella hídrica de una comida en la que predomina el "pescado blanco" figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado blanco medio (a partir del trabajo de consolidación sobre el consumo medio de pescado blanco del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | m3/kg | L |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** | | | |
-    | PB | 150 | 127,71 | 27,81 | 1,82 | 0,63 | 94,0 | Pescado blanco
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 6,19 1856
-    | Aceite de oliva virgen extra 17270 5 45 0 5 22,04 110
-    | **Postre** | | | | | | | | | | | | | | | | | | | | | | | |
-    | Postre mediano DE 200 186,39 5,36 12,11 5,20 1041
-    | Pan 7001 50 142 4,14 0,7 0,29 14,5
-    | Total: 705, 584,02, 48,93, 10,33, **3115**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.lock: |
-    L'empreinte eau d'un repas à dominate "poisson blanc" est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) |   m3/kg   |    L     |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson blanc               | PB     | 150     | 127,71 | 27,81         | 1,82        | 0,63      |  94,0    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 6,19      |  1856    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 22,04      |  110    |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 5,20      |  1041    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,29      |  14,5    |
-    | Total                       |        | 705     | 584,02 | 48,93         | 10,33       |           | **3115** |
+    Repas contenant 150g d'un poisson blanc moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons blancs de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -30973,58 +30643,25 @@ alimentation . plats . viande rouge . empreinte carbone:
   titre.auto: Huella de carbono de una comida de carne roja (ternera, buey, cordero)
   titre.lock: Empreinte carbone d'un repas de type viande rouge (bœuf, veau, agneau)
   note: |
-    La huella de carbono de una comida en la que predomine la carne roja (ternera, buey, cordero, etc.) se indica en el cuadro siguiente:
+    Comida que contiene 150 g de una carne roja media (basada en la consolidación del consumo medio de carne roja del estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Carne Roja VR 150 209,58 30,15 9,82 27,08 4,06
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 775,08, 55,37, 30,44, 4,79
-
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
     En cuanto a la deforestación, nuestros alimentos provocan deforestación en el extranjero, lo que tiene un importante impacto de carbono. Esta huella no está incluida en los factores de emisión de Agribalyse.
 
-    Según el estudio de <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al</a>., una parte de esta deforestación está asociada específicamente al consumo de carne de granja.
+    Según el estudio de <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al.</a>, una parte de esta deforestación está específicamente asociada al consumo de carne de granja.
     Consideramos que esta parte asociada a la "carne de cría" está principalmente asociada al consumo de carne roja, por lo que añadimos esta parte de deforestación a las comidas de carne roja.
   note.auto: |
-    La huella de carbono de una comida en la que predomine la carne roja (ternera, buey, cordero, etc.) se indica en el cuadro siguiente:
+    Comida que contiene 150 g de una carne roja media (basada en la consolidación del consumo medio de carne roja del estudio INCA3), una guarnición media (basada en el consumo medio de verduras, legumbres, arroz, cereales y pasta) y aceite.
 
-    | CIQUAL | Qte (g) | Kcal | Proteína (g) | Grasa (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | |
-    | Carne Roja VR 150 209,58 30,15 9,82 27,08 4,06
-    | Acompañamiento mediano AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 775,08, 55,37, 30,44, 4,79
-
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
     En cuanto a la deforestación, nuestros alimentos provocan deforestación en el extranjero, lo que tiene un importante impacto de carbono. Esta huella no está incluida en los factores de emisión de Agribalyse.
 
-    Según el estudio de <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al</a>., una parte de esta deforestación está asociada específicamente al consumo de carne de granja.
+    Según el estudio de <a href="https://iopscience.iop.org/article/10.1088/1748-9326/ab0d41">Pendril & al.</a>, una parte de esta deforestación está específicamente asociada al consumo de carne de granja.
     Consideramos que esta parte asociada a la "carne de cría" está principalmente asociada al consumo de carne roja, por lo que añadimos esta parte de deforestación a las comidas de carne roja.
   note.lock: |
-    L'empreinte carbone d'un repas à dominate "viande rouge" (boeuf, veau, agneau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Viande rouge                | VR     | 150     | 209,58 | 30,15         | 9,82        | 27,08     |  4,06    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 775,08 | 55,37         | 30,44       |           | **4,79** |
+    Repas contenant 150g d'une viande rouge moyenne (issue d'un travail de consolidation sur les consommations moyennes de viande rouge de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 
@@ -31086,52 +30723,19 @@ alimentation . plats . poisson gras . empreinte carbone:
   titre.auto: Huella de carbono de una comida de pescado azul (atún, salmón, sardinas, caballa)
   titre.lock: Empreinte carbone d'un repas de type poisson gras (thon, saumon, sardine, maquereau)
   description: |
-    La huella de carbono de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado graso medio (a partir del trabajo de consolidación sobre el consumo medio de pescado graso del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Pescado graso PG 150 290,27 33,16 17,16 3,85 0,58
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 855,77, 58,38, 37,79, **1,31**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.auto: |
-    La huella de carbono de una comida en la que predomine el "pescado azul" (atún, salmón, sardinas, caballa, etc.) figura en el cuadro siguiente:
+    Comida que contiene 150 g de un pescado graso medio (a partir del trabajo de consolidación sobre el consumo medio de pescado graso del estudio INCA3), una guarnición media (consolidación sobre el consumo medio de verduras, legumbres, arroz, cereales y pasta), aceite.
 
-    | Ingredientes | CIQUAL | Cantidad (g) | Kcal | Proteínas (g) | Grasas (g) | kgCO2e/kg | kgCO2e |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Enterée + plat principal** | | | | | | | | | | |
-    | Pescado graso PG 150 290,27 33,16 17,16 3,85 0,58
-    | Acompañamiento medio AM 300 192,11 15,72 2,81 1,26 0,38
-    | Aceite de oliva virgen extra 17270 5 45 0 5 0,98 0
-    | **Postre** | | | | | | | | | | |
-    | Postre medio DE 200 186,39 5,36 12,11 1,57 0,31
-    | Pan 7001 50 142 4,14 0,7 0,69 0,03
-    | Total: 705, 855,77, 58,38, 37,79, **1,31**
+    💡 Puedes encontrar la documentación completa en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
 
-    💡 La documentación completa se puede encontrar en <a href="https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23">nuestra wiki</a>.
-
-    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> como hoja de cálculo.
+    🧮 El cálculo detallado está <a href="https://docs.google.com/spreadsheets/d/1L3p1m2jtbSK7f3i9AYvWIHntXhI_IiVIY9RM6-IxTb8/edit#gid=1235090355">disponible aquí</a> en forma de hoja de cálculo.
   description.lock: |
-    L'empreinte carbone d'un repas à dominate "poisson gras" (thon, saumon, sardine, maquereau...) est donné par le tableau suivant :
-
-    | Ingrédients                 | CIQUAL | Qte (g) | Kcal   | Protéines (g) | Lipides (g) | kgCO2e/kg |  kgCO2e  |
-    | --------------------------- | ------ | ------- | ------ | ------------- | ----------- | --------- | -------- |
-    | **Entrée + plat principal** |        |         |        |               |             |           |          |
-    | Poisson gras                | PG     | 150     | 290,27 | 33,16         | 17,16       | 3,85      |  0,58    |
-    | Accompagnement moyen        | AM     | 300     | 192,11 | 15,72         | 2,81        | 1,26      |  0,38    |
-    | Huile d'olive vierge extra  | 17270  | 5       | 45     | 0             | 5           | 0,98      |  0       |
-    |   **Dessert**               |        |         |        |               |             |           |          |
-    | Dessert moyen               | DE     | 200     | 186,39 | 5,36          | 12,11       | 1,57      |  0,31    |
-    | Pain                        | 7001   | 50      | 142    | 4,14          | 0,7         | 0,69      |  0,03    |
-    | Total                       |        | 705     | 855,77 | 58,38         | 37,79       |           | **1,31** |
+    Repas contenant 150g d'un poisson gras moyen (issu d'un travail de consolidation sur les consommations moyennes de poissons gras de l'étude INCA3), un accompagnement moyen (consolidation sur les moyennes de consommation pour les légumes, légumineuses, riz, céréales et pâtes), huile.
 
     💡 Vous trouverez la documentation complète dans [notre wiki](https://accelerateur-transition-ecologique-ademe.notion.site/Empreinte-des-repas-NGC-377d2143f3a14b558ab2c8e0426d2e23).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incubateur-ademe/nosgestesclimat",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Le modèle de calcul d'empreinte climat individuelle de consommation",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Cette mise à jour est devenue prioritaire quand on a réalisé qu'elle divisait plus ou moins par deux l'empreinte eau des repas.