### PR TITLE
Remove VAE from question on transport

### DIFF
--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -18646,7 +18646,7 @@ transport . mobilité douce . vélo . durée de vie:
 transport . mobilité douce . vae:
   titre: Electric bikes
   titre.auto: Electric bikes
-  titre.lock: Vélo électrique (VAE)
+  titre.lock: Vélo électrique
   note: |
     Electrically-assisted cargo bikes belong in the EAB category. The difference in motorization and weight, and therefore footprint, is too slight to merit a separate category.
   note.auto: |

--- a/data/transport/mobilité douce.publicodes
+++ b/data/transport/mobilité douce.publicodes
@@ -58,7 +58,7 @@ transport . mobilité douce . vélo . durée de vie:
     Chiffres tirés de l'étude ADEME de 2019 ["Modélisation et évaluation environnementale de produits de consommation et biens d'équipement"](https://librairie.ademe.fr/dechets-economie-circulaire/127-modelisation-et-evaluation-environnementale-de-produits-de-consommation-et-biens-d-equipement.html)
 
 transport . mobilité douce . vae:
-  titre: Vélo électrique (VAE)
+  titre: Vélo électrique
   icônes: 🚲
   applicable si: présent
   formule: empreinte * km + construction amortie


### PR DESCRIPTION
VAE est du jargon, petite suggestion pour le retirer de la question. 

Mais je ne sais pas si ça suffit pour que ça s'enlève aussi du mode scolaire