### PR TITLE
Fix : Doublon du cycle de vie informatique

### DIFF
--- a/data/empreinte/divers/numérique.publicodes
+++ b/data/empreinte/divers/numérique.publicodes
@@ -79,8 +79,8 @@ divers . numérique . internet . empreinte horaire:
       - si: métrique = "carbone"
         alors:
           moyenne:
-            - 0.0523 kgCO2e/h
-            - 0.0311 kgCO2e/h
+            - 0.0013 kgCO2e/h
+            - 0.0084 kgCO2e/h
       - si: métrique = "eau"
         alors:
           moyenne:
@@ -94,12 +94,15 @@ divers . numérique . internet . empreinte horaire:
     - A4: Écoute de musique/podcast sur une plateforme de streaming (application) sur un smartphone connecté à internet via réseau mobile
     - V5: Visionnage de vidéo en ligne sur une plateforme de partage de vidéos en HD sur un smartphone connecté à internet via réseau mobile
 
+    L'impact du cycle de vie étant déjà pris en compte dans "divers . numérique . appareils", cette section concerne uniquement l'impact d'utilisation horaire.
+
     Pour le scénario A4, l'étude estime (cf page 329 du rapport):
-      - une empreinte carbone de 0.0131 kgCO2e/h soit 13.1 gCO2e/h.
+      - une empreinte carbone de soit 0,0013 kgCO2e/h.
+      - une empreinte carbone de la Consommation d'énergie finale de 4,13E-02 kW, soit 0,0013 kgCO2e/h sur la grille électrique française (moyenne 2025).
       - une empreinte eau de 0.000134 m3/h soit 0.134 l/h.
 
     Pour le scénario V5, l'étude estime (cf page 334 du rapport):
-      - une empreinte carbone de de 0.0523 kgCO2e/h soit 52.3 gCO2e/h.
+      - une empreinte carbone de la Consommation d'énergie finale de 2,62E-01 kW, soit 0,0084 kgCO2e/h sur la grille électrique française (moyenne 2025).
       - une empreinte eau de 0.000536 m3/h soit 0.536 l/h.
 
     Nous utilisons une moyenne de ces scénarios, **c'est une hypothèse forte (mais conservatrice)** car l'usage d'un smartphone pour de l'écoute musical ou visionnage vidéo n'est pas forcément représentatif de l'ensemble des usages d'internet (envoi de mails, surf web, streaming vidéo sur TV ou ordinateur, etc.).

--- a/data/empreinte/divers/numérique.publicodes
+++ b/data/empreinte/divers/numérique.publicodes
@@ -71,6 +71,7 @@ divers . numérique:
 
 divers . numérique . internet:
   icônes: 🌐
+  non applicable si: métrique != "carbone"
   formule: empreinte horaire * durée journalière * commun . jours par an
 
 divers . numérique . internet . empreinte horaire:
@@ -79,13 +80,8 @@ divers . numérique . internet . empreinte horaire:
       - si: métrique = "carbone"
         alors:
           moyenne:
-            - 0.0013 kgCO2e/h
-            - 0.0084 kgCO2e/h
-      - si: métrique = "eau"
-        alors:
-          moyenne:
-            - 0.536 l/h
-            - 0.504 l/h
+            - 0.00869 kgCO2e/h
+            - 0.02966 kgCO2e/h
   note: |
     En octobre 2024, l'ADEME accompagné la sortie de l'[étude de l'impact environnemental des usages audiovisuels en France](https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france) réalisée par l'Arcom et l'Arcep. Le rapport complet est disponible [ici](https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf).
 
@@ -94,16 +90,11 @@ divers . numérique . internet . empreinte horaire:
     - A4: Écoute de musique/podcast sur une plateforme de streaming (application) sur un smartphone connecté à internet via réseau mobile
     - V5: Visionnage de vidéo en ligne sur une plateforme de partage de vidéos en HD sur un smartphone connecté à internet via réseau mobile
 
-    L'impact du cycle de vie étant déjà pris en compte dans "divers . numérique . appareils", cette section concerne uniquement l'impact d'utilisation horaire.
+    L'impact de la fabrication des appareils étant déjà pris en compte ailleurs, cette section concerne uniquement l'impact des réseaux et centre de données.
 
-    Pour le scénario A4, l'étude estime (cf page 329 du rapport):
-      - une empreinte carbone de soit 0,0013 kgCO2e/h.
-      - une empreinte carbone de la Consommation d'énergie finale de 4,13E-02 kW, soit 0,0013 kgCO2e/h sur la grille électrique française (moyenne 2025).
-      - une empreinte eau de 0.000134 m3/h soit 0.134 l/h.
+    Pour le scénario A4, l'étude estime (cf page 329 du rapport) une empreinte carbone de 7,87e-3 + 8,22e-4 = 8,69e-3 kgCO2e/h.
 
-    Pour le scénario V5, l'étude estime (cf page 334 du rapport):
-      - une empreinte carbone de la Consommation d'énergie finale de 2,62E-01 kW, soit 0,0084 kgCO2e/h sur la grille électrique française (moyenne 2025).
-      - une empreinte eau de 0.000536 m3/h soit 0.536 l/h.
+    Pour le scénario V5, l'étude estime (cf page 334 du rapport) une empreinte carbone de 2,80e-2 + 1,66e-3 = 2,966e-2 kgCO2e/h.
 
     Nous utilisons une moyenne de ces scénarios, **c'est une hypothèse forte (mais conservatrice)** car l'usage d'un smartphone pour de l'écoute musical ou visionnage vidéo n'est pas forcément représentatif de l'ensemble des usages d'internet (envoi de mails, surf web, streaming vidéo sur TV ou ordinateur, etc.).
 

--- a/data/i18n/t9n/translated-rules-en.yaml
+++ b/data/i18n/t9n/translated-rules-en.yaml
@@ -4303,39 +4303,35 @@ divers . numérique . internet . empreinte horaire:
   titre.auto: hourly footprint
   titre.lock: empreinte horaire
   note: |
-    In October 2024, ADEME accompanied the release of the study<a href="https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france">on the environmental impact of audiovisual use in France</a>, carried out by Arcom and Arcep. The full report is available <a href="https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf">here</a>.
+    In October 2024, ADEME supported the publication of<a href="https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france">the study on the environmental impact of audiovisual usage in France</a>, carried out by Arcom and Arcep. The full report is available <a href="https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf">here</a>.
 
-    This study proposes different scenarios for Internet use and their environmental impact. We have selected 2 scenarios:
+    This study presents various scenarios for internet use and their environmental impacts. We have selected two scenarios:
 
-    - A4: Listening to music/podcasts on a streaming platform (application) on a smartphone connected to the internet via a mobile network
-    - V5: Watching online video on an HD video-sharing platform on a smartphone connected to the internet via a mobile network
+    - A4: Listening to music or podcasts on a streaming platform (app) via a smartphone connected to the internet via a mobile network
+    - V5: Watching online video in HD on a video-sharing platform via a smartphone connected to the internet via a mobile network
 
-    For scenario A4, the study estimates (see page 329 of the report):
-      - a carbon footprint of 0.0131 kgCO2e/h or 13.1 gCO2e/h.
-      - a water footprint of 0.000134 m3/h or 0.134 l/h.
+    As the environmental impact of manufacturing the devices has already been taken into account elsewhere, this section focuses solely on the impact of networks and data centres.
 
-    For scenario V5, the study estimates (see page 334 of the report):
-      - a carbon footprint of 0.0523 kgCO2e/h or 52.3 gCO2e/h.
-      - a water footprint of 0.000536 m3/h or 0.536 l/h.
+    For scenario A4, the study estimates (see page 329 of the report) a carbon footprint of 7.87e-3 + 8.22e-4 = 8.69e-3 kgCO2e/h.
 
-    We are using an average of these scenarios, **this is a strong (but conservative) assumption** because the use of a smartphone for listening to music or watching video is not necessarily representative of all Internet use (sending emails, surfing the web, streaming video on TV or computer, etc.).
+    For scenario V5, the study estimates (see page 334 of the report) a carbon footprint of 2.80e-2 + 1.66e-3 = 2.966e-2 kgCO2e/h.
+
+    We use an average of these scenarios; **this is a strong (but conservative) assumption**, as using a smartphone to listen to music or watch videos is not necessarily representative of all internet uses (sending emails, browsing the web, streaming video on a TV or computer, etc.).
   note.auto: |
-    In October 2024, ADEME accompanied the release of the study<a href="https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france">on the environmental impact of audiovisual use in France</a>, carried out by Arcom and Arcep. The full report is available <a href="https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf">here</a>.
+    In October 2024, ADEME supported the publication of<a href="https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france">the study on the environmental impact of audiovisual usage in France</a>, carried out by Arcom and Arcep. The full report is available <a href="https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf">here</a>.
 
-    This study proposes different scenarios for Internet use and their environmental impact. We have selected 2 scenarios:
+    This study presents various scenarios for internet use and their environmental impacts. We have selected two scenarios:
 
-    - A4: Listening to music/podcasts on a streaming platform (application) on a smartphone connected to the internet via a mobile network
-    - V5: Watching online video on an HD video-sharing platform on a smartphone connected to the internet via a mobile network
+    - A4: Listening to music or podcasts on a streaming platform (app) via a smartphone connected to the internet via a mobile network
+    - V5: Watching online video in HD on a video-sharing platform via a smartphone connected to the internet via a mobile network
 
-    For scenario A4, the study estimates (see page 329 of the report):
-      - a carbon footprint of 0.0131 kgCO2e/h or 13.1 gCO2e/h.
-      - a water footprint of 0.000134 m3/h or 0.134 l/h.
+    As the environmental impact of manufacturing the devices has already been taken into account elsewhere, this section focuses solely on the impact of networks and data centres.
 
-    For scenario V5, the study estimates (see page 334 of the report):
-      - a carbon footprint of 0.0523 kgCO2e/h or 52.3 gCO2e/h.
-      - a water footprint of 0.000536 m3/h or 0.536 l/h.
+    For scenario A4, the study estimates (see page 329 of the report) a carbon footprint of 7.87e-3 + 8.22e-4 = 8.69e-3 kgCO2e/h.
 
-    We are using an average of these scenarios, **this is a strong (but conservative) assumption** because the use of a smartphone for listening to music or watching video is not necessarily representative of all Internet use (sending emails, surfing the web, streaming video on TV or computer, etc.).
+    For scenario V5, the study estimates (see page 334 of the report) a carbon footprint of 2.80e-2 + 1.66e-3 = 2.966e-2 kgCO2e/h.
+
+    We use an average of these scenarios; **this is a strong (but conservative) assumption**, as using a smartphone to listen to music or watch videos is not necessarily representative of all internet uses (sending emails, browsing the web, streaming video on a TV or computer, etc.).
   note.lock: |
     En octobre 2024, l'ADEME accompagné la sortie de l'[étude de l'impact environnemental des usages audiovisuels en France](https://www.arcom.fr/se-documenter/etudes-et-donnees/etudes-bilans-et-rapports-de-larcom/etude-de-limpact-environnemental-des-usages-audiovisuels-en-france) réalisée par l'Arcom et l'Arcep. Le rapport complet est disponible [ici](https://www.arcom.fr/sites/default/files/2024-10/Arcom-arcep-ademe-etude-impact-environnemental-des-usages-audiovisuels.pdf).
 
@@ -4344,13 +4340,11 @@ divers . numérique . internet . empreinte horaire:
     - A4: Écoute de musique/podcast sur une plateforme de streaming (application) sur un smartphone connecté à internet via réseau mobile
     - V5: Visionnage de vidéo en ligne sur une plateforme de partage de vidéos en HD sur un smartphone connecté à internet via réseau mobile
 
-    Pour le scénario A4, l'étude estime (cf page 329 du rapport):
-      - une empreinte carbone de 0.0131 kgCO2e/h soit 13.1 gCO2e/h.
-      - une empreinte eau de 0.000134 m3/h soit 0.134 l/h.
+    L'impact de la fabrication des appareils étant déjà pris en compte ailleurs, cette section concerne uniquement l'impact des réseaux et centre de données.
 
-    Pour le scénario V5, l'étude estime (cf page 334 du rapport):
-      - une empreinte carbone de de 0.0523 kgCO2e/h soit 52.3 gCO2e/h.
-      - une empreinte eau de 0.000536 m3/h soit 0.536 l/h.
+    Pour le scénario A4, l'étude estime (cf page 329 du rapport) une empreinte carbone de 7,87e-3 + 8,22e-4 = 8,69e-3 kgCO2e/h.
+
+    Pour le scénario V5, l'étude estime (cf page 334 du rapport) une empreinte carbone de 2,80e-2 + 1,66e-3 = 2,966e-2 kgCO2e/h.
 
     Nous utilisons une moyenne de ces scénarios, **c'est une hypothèse forte (mais conservatrice)** car l'usage d'un smartphone pour de l'écoute musical ou visionnage vidéo n'est pas forcément représentatif de l'ensemble des usages d'internet (envoi de mails, surf web, streaming vidéo sur TV ou ordinateur, etc.).
 divers . numérique . internet . empreinte réduite:


### PR DESCRIPTION
Le cycle de vie des smartphones et ordinateurs est compté deux fois, dans `divers . numérique . internet . empreinte horaire` et `divers . numérique . appareils`.

L'erreur est non-négligeable, elle rajoute ~50 kg CO2 par défaut (et jusqu'à 300kg pour les usagers intensifs).

Je propose la solution suivante : utiliser le chiffre de la même étude de l'ADEME citée en source, mais sur la Consommation finale.